### PR TITLE
Patches listed in Source are not patches

### DIFF
--- a/source-checker.pl
+++ b/source-checker.pl
@@ -169,6 +169,9 @@ if (-d "$old") {
             if (m/^Source/) {
                 my $line = $_;
                 $line =~ s/^(Source[0-9]*)\s*:\s*//;
+                if ($patches{$line}) {
+                   delete $patches{$line};
+                }
                 my $prefix = $1;
                 my $parsedline = $ps->{lc $prefix};
                 if (defined $thash{$parsedline}) {


### PR DESCRIPTION
If a spec file gets another "SourceN: some-change.patch" it will be
rejected.  New Sources do not need to be listed in .changes, so drop
such file from internal list of patches.

Fixes #292

Signed-off-by: Olaf Hering <ohering@suse.de>