### PR TITLE
accept_command: import urllib2

### DIFF
--- a/osclib/accept_command.py
+++ b/osclib/accept_command.py
@@ -1,5 +1,6 @@
 import re
 import warnings
+import urllib2
 from xml.etree import cElementTree as ET
 
 from osc.core import change_request_state


### PR DESCRIPTION
We need urllib2 for this code piece:

'''
    def create_new_links(self, project, pkgname, oldspeclist):
        filelist = self.api.get_filelist_for_package(pkgname=pkgname, project=project, extension='spec')
        removedspecs = set(oldspeclist) - set(filelist)
        for spec in removedspecs:
            # Deleting all the packages that no longer have a .spec file
            url = self.api.makeurl(['source', project, spec[:-5]])
            print "Deleting package %s from project %s" % (spec[:-5], project)
            try:
                http_DELETE(url)
            except urllib2.HTTPError, err:
                if err.code == 404:
                    # the package link was not yet created, which was likely a mistake from earlier
                    pass
                else:
                    # If the package was there bug could not be delete, raise the error
                    raise
'''

otherwise, we can't handle the exception if the delete request failed (we have one .spec file less after checkin - actually, none left... but the package can't be removed anymore, as accept already did that for us)