### PR TITLE
use suffix instead of hardcoded number, it is wrong for 2-DVD

### DIFF
--- a/create_test_Factory_dvd-2.testcase
+++ b/create_test_Factory_dvd-2.testcase
@@ -1,5 +1,10 @@
-# common part
+## common part
+#ifdef __x86_64__
 system x86_64 rpm
+#endif
+#ifdef __ppc64le__
+system ppc64le rpm
+#endif
 namespace namespace:language(en_US) @SYSTEM
 
 job install provides pattern() = apparmor

--- a/create_test_dvds.sh
+++ b/create_test_dvds.sh
@@ -43,7 +43,7 @@ function regenerate_pl() {
 		echo "repo $i 0 solv $i.solv" >> $tcfile
 	fi
     done
-    cpp -E -U__ppc64__ -U__x86_64__ -D__$arch\__ $SCRIPTDIR/create_test_$target\_dvd-1.testcase >> $tcfile
+    cpp -E -U__ppc64__ -U__x86_64__ -D__$arch\__ $SCRIPTDIR/create_test_$target\_dvd-$suffix.testcase >> $tcfile
 
     out=$(mktemp)
     testsolv -r $tcfile > $out


### PR DESCRIPTION
important! had hot-patched on packagelists.