### PR TITLE
set Mail-Followup-To field

### DIFF
--- a/factory-package-news/announcer.py
+++ b/factory-package-news/announcer.py
@@ -100,6 +100,7 @@ msg = MIMEText(txt)
 msg['Subject'] = 'New Tumbleweed snapshot %s released!'%version
 msg['From'] = options.sender
 msg['To'] = options.to
+msg['Mail-Followup-To'] = options.to
 
 if options.dry:
     print "sending ..."


### PR DESCRIPTION
makes good MUAs send replies to the target list rather than the sender.
http://cr.yp.to/proto/replyto.html