### PR TITLE
Fix expected architectures

### DIFF
--- a/tests/fixtures/source/openSUSE:Factory:Staging:A/_meta
+++ b/tests/fixtures/source/openSUSE:Factory:Staging:A/_meta
@@ -16,9 +16,11 @@
     <path project="openSUSE:Factory:Build" repository="standard"/>
     <arch>i586</arch>
     <arch>x86_64</arch>
+    <arch>ppc64le</arch>
   </repository>
   <repository name="images" rebuild="direct" linkedbuild="all">
     <path project="openSUSE:Factory" repository="standard"/>
+    <arch>ppc64le</arch>
     <arch>x86_64</arch>
     <arch>i586</arch>
   </repository>

--- a/tests/fixtures/staging-meta-for-bootstrap-copy.xml
+++ b/tests/fixtures/staging-meta-for-bootstrap-copy.xml
@@ -16,14 +16,17 @@
      <path project="openSUSE:Factory:Staging" repository="standard"/>
        <arch>i586</arch>
        <arch>x86_64</arch>
+       <arch>ppc64le</arch>
   </repository>
   <repository linkedbuild="all" name="standard" rebuild="direct">
     <path project="openSUSE:Factory:Staging:A" repository="bootstrap_copy"/>
     <arch>i586</arch>
     <arch>x86_64</arch>
+    <arch>ppc64le</arch>
   </repository>
   <repository linkedbuild="all" name="images" rebuild="direct">
     <path project="openSUSE:Factory:Staging:A" repository="standard"/>
     <arch>x86_64</arch>
+    <arch>ppc64le</arch>
   </repository>
 </project>


### PR DESCRIPTION
With extention osc_freeze command to the new architecture, we've forgot
to add tests. Lets fix it

Signed-off-by: Dinar Valeev <dvaleev@suse.com>