### PR TITLE
Avoid double quoting on http_GET

### DIFF
--- a/osclib/stagingapi.py
+++ b/osclib/stagingapi.py
@@ -78,7 +78,6 @@ class StagingAPI(object):
         return makeurl(self.apiurl, l, query)
 
     def retried_GET(self, url):
-        url = urllib2.quote(url, safe=':/?=&')
         try:
             return http_GET(url)
         except urllib2.HTTPError, e:

--- a/totest-manager.py
+++ b/totest-manager.py
@@ -83,8 +83,8 @@ class ToTestBase(object):
         """
 
         group = ' '.join(('openSUSE', self.openqa_version(), self.openqa_group())).strip()
-        url = 'https://openqa.opensuse.org/api/v1/' \
-              'jobs?version={}&build={}&distri=opensuse&group={}'.format(self.openqa_version(), snapshot, group)
+        url = urllib2.quote('https://openqa.opensuse.org/api/v1/' \
+                'jobs?version={}&build={}&distri=opensuse&group={}'.format(self.openqa_version(), snapshot, group), safe=':/?=&')
         f = self.api.retried_GET(url)
         jobs = []
         for job in json.load(f)['jobs']:


### PR DESCRIPTION
http_GET is supposed to retreive the url as per request. url is
generally constructed using makeurl, which already encodes it.

In the rare case where we construct the url ourselves (openQA api
requests), we take care of quoting before passing it on to http_GET