### PR TITLE
Unset nullglob after counting RPMs

### DIFF
--- a/create_test_dvds.sh
+++ b/create_test_dvds.sh
@@ -84,6 +84,7 @@ function sync_prj() {
     if [ "$dir" -nt "$dir.solv" ]; then
         shopt -s nullglob
         rpms=($dir/*.rpm)
+        shopt -u nullglob
         if [ "${#rpms[@]}" -gt 0 ]; then
             local start=$SECONDS
             rpms2solv "${rpms[@]}" > $dir.solv


### PR DESCRIPTION
If nullglub sets, seems it will affect the following osc api call for finding matched projects as like as the error below,

osc api: takes exactly 1 argument (0 given)

thus unset nullglob after counting RPMs.