### PR TITLE
Add the appropriate kernel to testcase

### DIFF
--- a/create_test_Factory_dvd-1.testcase
+++ b/create_test_Factory_dvd-1.testcase
@@ -29,9 +29,13 @@ job lock name gtk3-branding-upstream
 job lock name icewm-default
 #ifdef __x86_64__
 job install name openSUSE-release-livecd-x11
+job install name kernel-desktop
 job lock name kernel-default
 job lock name libgcc_s1-32bit
 job lock name nss-mdns-32bit
+#endif
+#ifdef __ppc64le__
+job install name kernel-default
 #endif
 job lock name patterns-openSUSE-enhanced_base_opt
 job lock name patterns-openSUSE-fonts_opt


### PR DESCRIPTION
Due to pattern_base's change, add the appropriate kernel to testcase. kernel-desktop for x86_64 and kernel-default for ppc64le.

If I understand https://github.com/yast/yast-yast2/blob/master/library/system/src/modules/Kernel.rb correct, the kernel flavor should be right here.