### PR TITLE
ports: make sure to not add ports over ports

### DIFF
--- a/osclib/accept_command.py
+++ b/osclib/accept_command.py
@@ -174,7 +174,7 @@ class AcceptCommand(object):
         ports_prjs = ['PowerPC', 'ARM' ]
 
         for ports in ports_prjs:
-            project = project + ':' + ports
+            project = self.api.project + ':' + ports
             if self.api.item_exists(project):
                 baseurl = ['source', project, '_product']
                 url = self.api.makeurl(baseurl, query=service)


### PR DESCRIPTION
Without this, we have code like this:

project = self.api.project
for ports in ports_prjs:
            project = project + ':' + ports

Which results in
1) openSUSE:Factory:PowerPC
2) openSUSE:Factory:PowerPC:ARM

the 2nd obviously wrong.