### PR TITLE
Fixes the logic error in checkTagNotRequired()

### DIFF
--- a/ReviewBot.py
+++ b/ReviewBot.py
@@ -194,7 +194,7 @@ class ReviewBot(object):
         url = osc.core.makeurl(apiurl, ('source', project, package), query=query)
         try:
             return ET.parse(osc.core.http_GET(url)).getroot()
-        except urllib2.HTTPError:
+        except (urllib2.HTTPError, urllib2.URLError):
             return None
 
     def get_originproject(self, project, package, rev=None):

--- a/check_tags_in_requests.py
+++ b/check_tags_in_requests.py
@@ -37,6 +37,12 @@ except ImportError:
     # python 2.x
     from urllib2 import HTTPError
 
+try:
+    from urllib.error import URLError
+except ImportError:
+    # python 2.x
+    from urllib2 import URLError
+
 import ReviewBot
 
 import check_source_in_factory
@@ -88,26 +94,16 @@ Note: there is no whitespace behind before or after the number sign
             return False
         return True
 
-    def isNewPackage(self, tgt_project, tgt_package):
-        try:
-            self.logger.debug("package_meta %s %s/%s" % (self.apiurl, tgt_project, tgt_package))
-            osc.core.show_package_meta(self.apiurl, tgt_project, tgt_package)
-        except HTTPError:
-            return True
-        return False
-
     def checkTagNotRequired(self, req, a):
         # if there is no diff, no tag is required
         diff = osc.core.request_diff(self.apiurl, req.reqid)
         if not diff:
             return True
 
-        # A tag is not required only if the package is
+        # 1) A tag is not required only if the package is
         # already in Factory with the same revision,
         # and the package is being introduced, not updated
-        is_new = self.isNewPackage(a.tgt_project, a.tgt_package)
-        if not is_new:
-            return False
+        # 2) A new package must be have a issue tag
         factory_checker = check_source_in_factory.FactorySourceChecker(apiurl=self.apiurl,
                                                                        dryrun=self.dryrun,
                                                                        logger=self.logger,


### PR DESCRIPTION
Maybe I'm wrong, but this logic should be the properly one I assume

use ''if not is_new: '' once the package is not a new package it will return False and quit the function, then I guess the following factorySourceChecker will not execute.