### PR TITLE
Memoize get_prj_pseudometa results

### DIFF
--- a/tests/api_tests.py
+++ b/tests/api_tests.py
@@ -46,6 +46,10 @@ class TestApiCalls(unittest.TestCase):
         Config('openSUSE:Factory')
         self.api = StagingAPI(APIURL, 'openSUSE:Factory')
 
+    def tearDown(self):
+        """Clean internal cache"""
+        self.api._invalidate_all()
+
     def test_ring_packages(self):
         """
         Validate the creation of the rings.


### PR DESCRIPTION
To avoid hit multiple times the OBS server asking for the _meta content in the staging project, I use a memoization version of `get_prj_pseudometa`.

This will cause problems with the `select` command, that will update the description field with some YAML metadata, causing `get_prj_pseudometa` returning outdated information.

To resolve this issue I also provide a mechanism to externally invalidate the memoization content from one specific set of parameter, adding a new dynamic method to the class.  So for every memoized method, a new `_invalidate_XXXX` method is created.