### PR TITLE
Execute based on permission

### DIFF
--- a/osclib/adi_command.py
+++ b/osclib/adi_command.py
@@ -103,4 +103,5 @@ class AdiCommand:
             self.create_new_adi(requests)
         else:
             self.check_adi_projects() 
-            self.create_new_adi(())
+            if self.api.is_user_member_of(self.api.user, 'factory-staging'):
+                self.create_new_adi(())

--- a/osclib/stagingapi.py
+++ b/osclib/stagingapi.py
@@ -27,6 +27,7 @@ from osc import conf
 from osc import oscerr
 from osc.core import change_review_state
 from osc.core import delete_package
+from osc.core import get_group
 from osc.core import get_request
 from osc.core import make_meta_url
 from osc.core import makeurl
@@ -58,6 +59,7 @@ class StagingAPI(object):
         self.crebuild = conf.config[project]['rebuild']
         self.cproduct = conf.config[project]['product']
         self.copenqa = conf.config[project]['openqa']
+        self.user = conf.get_apiurl_usr(apiurl)
 
         # If the project support rings, inititialize some variables.
         self.ring_packages = {}
@@ -1148,3 +1150,11 @@ class StagingAPI(object):
         http_PUT(url, data=meta)
 
         return name
+
+    def is_user_member_of(self, user, group):
+        root = ET.fromstring(get_group(self.apiurl, group))
+
+        if root.findall("./person/person[@userid='%s']" % user):
+            return True
+        else:
+            return False

--- a/tests/fixtures/group/factory-staging
+++ b/tests/fixtures/group/factory-staging
@@ -1,0 +1,7 @@
+<group>
+  <title>factory-staging</title>
+  <person>
+    <person userid="Admin"/>
+  </person>
+</group>
+

--- a/tests/obs.py
+++ b/tests/obs.py
@@ -25,7 +25,7 @@ import httpretty
 import osc
 
 
-APIURL = 'https://localhost'
+APIURL = 'http://localhost'
 
 FIXTURES = os.path.join(os.getcwd(), 'tests/fixtures')
 


### PR DESCRIPTION
I for one can start 'osc staging adi', it gives me an overview of "what's missing" and it accepts the 'ready stagings"; but as I'm not member of factory-staging, the creation of new staging projects, and moving requests to them, fails with a permission denied.

This change set performs a check if the user starting the command is member of factory-staging and only conditionally executes the 2nd part.