### PR TITLE
manager_42: fix scope usage of _cached_GET

### DIFF
--- a/manager_42.py
+++ b/manager_42.py
@@ -81,7 +81,7 @@ class UpdateCrawler(object):
 
     def cached_GET(self, url):
         if self.caching:
-            return _cached_GET(url)
+            return self._cached_GET(url)
         return http_GET(url).read()
 
     def get_source_packages(self, project, expand=False):


### PR DESCRIPTION
Otherwise, we run into:

Traceback (most recent call last):
  File "./manager_42.py", line 434, in <module>
    sys.exit(main(args))
  File "./manager_42.py", line 388, in main
    uc = UpdateCrawler(args.from_prj, caching = args.no_cache )
  File "./manager_42.py", line 76, in __init__
    self.packages[project] = self.get_source_packages(project)
  File "./manager_42.py", line 93, in get_source_packages
    query=query)))
  File "./manager_42.py", line 84, in cached_GET
    return _cached_GET(url)
NameError: global name '_cached_GET' is not defined
