### PR TITLE
Fixing wrong parsing $l from $prj

### DIFF
--- a/create_test_dvds.sh
+++ b/create_test_dvds.sh
@@ -136,7 +136,7 @@ function start_creating() {
             projects=$(osc api "/search/project/id?match=starts-with(@name,\"openSUSE:$target:Staging\")" | grep name | cut -d\' -f2)
 
             for prj in $projects; do
-                l=$(echo $prj | cut -d: -f4)
+                l=$(echo $prj | sed 's/^openSUSE.\+[:]Staging/Staging/g' | cut -d: -f2)
                 use_bc="staging_$target:$l-bc-$arch"
                 if [ "$l" = "A" -o "$l" = "B" ]; then
                     use_bc=


### PR DESCRIPTION
Staging project under openSUSE:Leap:42.1:Staging can not match the
original condition as it is not at the forth place in case separate by
colon. Use sed replacing the string from the first word till :Staging
to 'Staging' and pick the second place after separated by colon.