### PR TITLE
ttm: publish expected versions to better sync /snapshot with ftp tree

### DIFF
--- a/totest-manager.py
+++ b/totest-manager.py
@@ -318,6 +318,7 @@ class ToTestBase(object):
         print 'Updating snapshot %s' % snapshot
         if not self.dryrun:
             self.api.switch_flag_in_prj('openSUSE:%s:ToTest' % self.project, flag='publish', state='disable')
+            self.write_version_to_dashboard("totest", new_snapshot)
 
         for product in self.ftp_products:
             self.release_package('openSUSE:%s' % self.project, product)
@@ -332,6 +333,7 @@ class ToTestBase(object):
         print 'Publish ToTest'
         if not self.dryrun:
             self.api.switch_flag_in_prj('openSUSE:%s:ToTest' % self.project, flag='publish', state='enable')
+            self.write_version_to_dashboard("snapshot", current_snapshot)
 
     def totest_is_publishing(self):
         """Find out if the publishing flag is set in totest's _meta"""
@@ -397,6 +399,9 @@ class ToTestBase(object):
                 known_failures.append(line.strip())
         return known_failures
 
+    def write_version_to_dashboard(self, target, version):
+        url = self.api.makeurl(['source', 'openSUSE:%s:Staging' % self.project, 'dashboard', 'version_%s' % target])
+        http_PUT(url + '?comment=Update+version', data=version)
 
 class ToTestFactory(ToTestBase):
     main_products = ['_product:openSUSE-dvd5-dvd-i586',


### PR DESCRIPTION

This should produce the files
* version_totest
* version_snapshot
in the Staging/dashboard, which represents the versions that we expect to be part of the repo.

together with the new cron script, we should thus get FTP Tree and openSUSE:Factory/snapshot rather close together

This is 100% untested so far (but seems to make sense to me.. so please carefully review)