### PR TITLE
Check subproject is exist before delete package

### DIFF
--- a/osclib/stagingapi.py
+++ b/osclib/stagingapi.py
@@ -697,7 +697,11 @@ class StagingAPI(object):
 
         ring_dvd = '{}:2-TestDVD'.format(self.crings)
         if self.ring_packages.get(pkg) == ring_dvd:
-            return project + ":DVD"
+            if not self.item_exists(project + ":DVD") and self.item_exists(project, pkg):
+                # assuming it is in adi staging, workaround for https://progress.opensuse.org/issues/9646
+                return project
+            else:
+                return project + ":DVD"
 
         return project
 


### PR DESCRIPTION
It's workaound for https://progress.opensuse.org/issues/9646, suppose it is adi staging in case current project doesn't have ":DVD" subproject and the package is exist in current project.