### PR TITLE
ttm: collect all machine types

### DIFF
--- a/totest-manager.py
+++ b/totest-manager.py
@@ -156,11 +156,11 @@ class ToTestBase(object):
         in_progress = False
         machines = []
         for job in jobs:
+            machines.append(job['settings']['MACHINE'])
             # print json.dumps(job, sort_keys=True, indent=4)
             if job['result'] in ('failed', 'incomplete', 'skipped', 'user_cancelled', 'obsoleted'):
                 jobname = job['name'] + '@' + job['settings']['MACHINE']
                 # Record machines we have tests for
-                machines.append(job['settings']['MACHINE'])
                 if jobname in self.known_failures:
                     self.known_failures.remove(jobname)
                     continue


### PR DESCRIPTION
Only adding machine types to the list if the test fails means we do not
list 'Now passing' messages for any Machine Type that has all issues solved.