### PR TITLE
Implement configurable review mode

### DIFF
--- a/ReviewBot.py
+++ b/ReviewBot.py
@@ -68,7 +68,7 @@ class ReviewBot(object):
 
     @review_mode.setter
     def review_mode(self, value):
-        if value not in REVIEW_CHOICES:
+        if value not in self.REVIEW_CHOICES:
             raise Exception("invalid review option: %s"%value)
         self._review_mode = value
 
@@ -365,6 +365,15 @@ class CommandLineInterface(cmdln.Cmdln):
 
         self.checker = self.setup_checker()
 
+        if self.options.review_mode:
+            self.checker.review_mode = self.options.review_mode
+
+        if self.options.fallback_user:
+            self.checker.fallback_user = self.options.fallback_user
+
+        if self.options.fallback_group:
+            self.checker.fallback_group = self.options.fallback_group
+
     def setup_checker(self):
         """ reimplement this """
 
@@ -377,22 +386,11 @@ class CommandLineInterface(cmdln.Cmdln):
         if user is None and group is None:
             user = osc.conf.get_apiurl_usr(apiurl)
 
-        bot = ReviewBot(apiurl = apiurl, \
+        return ReviewBot(apiurl = apiurl, \
                 dryrun = self.options.dry, \
                 user = user, \
                 group = group, \
                 logger = self.logger)
-
-        if self.options.review_mode:
-            bot.review_mode = self.options.review_mode
-
-        if self.options.fallback_user:
-            bot.fallback_user = self.options.fallback_user
-
-        if self.options.fallback_group:
-            bot.fallback_group = self.options.fallback_group
-
-        return bot
 
     def do_id(self, subcmd, opts, *args):
         """${cmd_name}: check the specified request ids

--- a/ReviewBot.py
+++ b/ReviewBot.py
@@ -69,7 +69,7 @@ class ReviewBot(object):
     @review_mode.setter
     def review_mode(self, value):
         if value not in REVIEW_CHOICES:
-            raise Exception("invalid review option: %s", value)
+            raise Exception("invalid review option: %s"%value)
         self._review_mode = value
 
     def set_request_ids(self, ids):
@@ -83,8 +83,8 @@ class ReviewBot(object):
 
     def check_requests(self):
 
-        by_user = self.fallback_user if self.fallback_user else None
-        by_group = self.fallback_group if self.fallback_group else None
+        by_user = self.fallback_user
+        by_group = self.fallback_group
 
         for req in self.requests:
             self.logger.debug("checking %s"%req.reqid)

--- a/ReviewBot.py
+++ b/ReviewBot.py
@@ -48,6 +48,7 @@ class ReviewBot(object):
     """
 
     DEFAULT_REVIEW_MESSAGES = { 'accepted' : 'ok', 'declined': 'review failed' }
+    REVIEW_CHOICES = ('normal', 'no', 'accept', 'fallback-onfail', 'fallback-always')
 
     def __init__(self, apiurl = None, dryrun = False, logger = None, user = None, group = None):
         self.apiurl = apiurl
@@ -57,6 +58,19 @@ class ReviewBot(object):
         self.review_group = group
         self.requests = []
         self.review_messages = ReviewBot.DEFAULT_REVIEW_MESSAGES
+        self._review_mode = 'normal'
+        self.fallback_user = None
+        self.fallback_group = None
+
+    @property
+    def review_mode(self):
+        return self._review_mode
+
+    @review_mode.setter
+    def review_mode(self, value):
+        if value not in REVIEW_CHOICES:
+            raise Exception("invalid review option: %s", value)
+        self._review_mode = value
 
     def set_request_ids(self, ids):
         for rqid in ids:
@@ -68,9 +82,18 @@ class ReviewBot(object):
             self.requests.append(req)
 
     def check_requests(self):
+
+        by_user = self.fallback_user if self.fallback_user else None
+        by_group = self.fallback_group if self.fallback_group else None
+
         for req in self.requests:
             self.logger.debug("checking %s"%req.reqid)
             good = self.check_one_request(req)
+
+            if self.review_mode == 'no':
+                good = None
+            elif self.review_mode == 'accept':
+                good = True
 
             if good is None:
                 self.logger.info("%s ignored"%req.reqid)
@@ -78,8 +101,13 @@ class ReviewBot(object):
                 self.logger.info("%s is good"%req.reqid)
                 self._set_review(req, 'accepted')
             else:
-                self.logger.info("%s is not acceptable"%req.reqid)
-                self._set_review(req, 'declined')
+                if self.review_mode == 'fallback-onfail':
+                    self.logger.info("%s needs fallback reviewer"%req.reqid)
+                    self.add_review(req, by_group=by_group, by_user=by_user)
+                    self._set_review(req, 'accepted')
+                else:
+                    self.logger.info("%s is not acceptable"%req.reqid)
+                    self._set_review(req, 'declined')
 
     def _set_review(self, req, state):
         doit = self.can_accept_review(req.reqid)
@@ -314,6 +342,9 @@ class CommandLineInterface(cmdln.Cmdln):
         parser.add_option("--debug", action="store_true", help="debug output")
         parser.add_option("--osc-debug", action="store_true", help="osc debug output")
         parser.add_option("--verbose", action="store_true", help="verbose")
+        parser.add_option("--review-mode", dest='review_mode', choices=ReviewBot.REVIEW_CHOICES, help="review behavior")
+        parser.add_option("--fallback-user", dest='fallback_user', metavar='USER', help="fallback review user")
+        parser.add_option("--fallback-group", dest='fallback_group', metavar='GROUP', help="fallback review group")
 
         return parser
 
@@ -346,11 +377,22 @@ class CommandLineInterface(cmdln.Cmdln):
         if user is None and group is None:
             user = osc.conf.get_apiurl_usr(apiurl)
 
-        return ReviewBot(apiurl = apiurl, \
+        bot = ReviewBot(apiurl = apiurl, \
                 dryrun = self.options.dry, \
                 user = user, \
                 group = group, \
                 logger = self.logger)
+
+        if self.options.review_mode:
+            bot.review_mode = self.options.review_mode
+
+        if self.options.fallback_user:
+            bot.fallback_user = self.options.fallback_user
+
+        if self.options.fallback_group:
+            bot.fallback_group = self.options.fallback_group
+
+        return bot
 
     def do_id(self, subcmd, opts, *args):
         """${cmd_name}: check the specified request ids


### PR DESCRIPTION
The new parameter --review-mode allows to specify how the review bot should handle obs reviews

normal: accept review if check is good, decline if bad
no: don't accept or decline requests
accept: always accept review, even if check fails
fallback-onfail: accept review and set other user or group as review if check fails
fallback-always: always accept review and set other user or group as reviewer afterwards