### PR TITLE
Revert "make sure to only release the 'images' repo"

### DIFF
--- a/totest-manager.py
+++ b/totest-manager.py
@@ -307,9 +307,6 @@ class ToTestBase(object):
 
         if set_release:
             query['setrelease'] = set_release
-        # FIXME: make configurable. openSUSE:Factory:ARM currently has multiple
-        # repos with release targets, so obs needs to know which one to release
-        query['repository'] = 'images'
 
         baseurl = ['source', project, package]
 


### PR DESCRIPTION
openSUSE:Factory:Live has no 'images' repository to release, but a standard

This reverts commit 8f4e97598fc255b1283661c80444307f80e6ae4f.