### PR TITLE
Do not check totest on SLE

### DIFF
--- a/osc-staging.py
+++ b/osc-staging.py
@@ -172,26 +172,42 @@ def do_staging(self, subcmd, opts, *args):
                 print "%s last frozen %0.1f days ago" % (api.prj_from_letter(prj), api.days_since_last_freeze(api.prj_from_letter(prj)))
         elif cmd == 'acheck':
             # Is it safe to accept? Meaning: /totest contains what it should and is not dirty
-            version_openqa = api.load_file_content("%s:Staging" % api.project, "dashboard", "version_totest")
             version_totest = api.get_binary_version(api.project, "openSUSE-release.rpm", repository="totest", arch="x86_64")
-            totest_dirty = api.is_repo_dirty(api.project, 'totest')
-            print "version_openqa: %s / version_totest: %s / totest_dirty: %s\n" % (version_openqa, version_totest, totest_dirty)
+            skip_totest = False
+            if not version_totest:
+                # SLE don't have totest repository and openSUSE-release.rpm
+                skip_totest = api.item_exists(api.project, "release-notes-sles")
+
+            if not skip_totest:
+                version_openqa = api.load_file_content("%s:Staging" % api.project, "dashboard", "version_totest")
+                totest_dirty = api.is_repo_dirty(api.project, 'totest')
+                print "version_openqa: %s / version_totest: %s / totest_dirty: %s\n" % (version_openqa, version_totest, totest_dirty)
+            else:
+                print "acheck is unavailable in %s!\n" % (api.project)
         elif cmd == 'accept':
             # Is it safe to accept? Meaning: /totest contains what it should and is not dirty
-            version_openqa = api.load_file_content("%s:Staging" % api.project, "dashboard", "version_totest")
             version_totest = api.get_binary_version(api.project, "openSUSE-release.rpm", repository="totest", arch="x86_64")
-            totest_dirty   = api.is_repo_dirty(api.project, 'totest')
-            if (version_openqa == version_totest and not totest_dirty) or opts.force:
-                cmd = AcceptCommand(api)
-                for prj in args[1:]:
-                    if not cmd.perform(api.prj_from_letter(prj)):
-                        return
-                cmd.accept_other_new()
-                cmd.update_factory_version()
-                if api.item_exists(api.crebuild):
-                    cmd.sync_buildfailures()
+            skip_totest = False
+            if not version_totest:
+                # SLE don't have totest repository and openSUSE-release.rpm
+                skip_totest = api.item_exists(api.project, "release-notes-sles")
+
+            if not skip_totest:
+                version_openqa = api.load_file_content("%s:Staging" % api.project, "dashboard", "version_totest")
+                totest_dirty   = api.is_repo_dirty(api.project, 'totest')
+                if (version_openqa == version_totest and not totest_dirty) or opts.force:
+                    cmd = AcceptCommand(api)
+                    for prj in args[1:]:
+                        if not cmd.perform(api.prj_from_letter(prj)):
+                            return
+                    cmd.accept_other_new()
+                    cmd.update_factory_version()
+                    if api.item_exists(api.crebuild):
+                        cmd.sync_buildfailures()
+                else:
+                    print "Not safe to accept: /totest is not yet synced"
             else:
-                print "Not safe to accept: /totest is not yet synced"
+                print "checking totest is unavailable in %s!\n" % (api.project)
         elif cmd == 'unselect':
             UnselectCommand(api).perform(args[1:])
         elif cmd == 'select':

--- a/osclib/stagingapi.py
+++ b/osclib/stagingapi.py
@@ -1020,7 +1020,10 @@ class StagingAPI(object):
         Return the version of a built rpm file
         """
         url = self.makeurl(['build', project, repository, arch, '_repository', "%s?view=fileinfo" % rpm])
-        return ET.parse(http_GET(url)).getroot().find('version').text
+        try:
+            return ET.parse(http_GET(url)).getroot().find('version').text
+        except urllib2.HTTPError:
+            return None
 
     def load_file_content(self, project, package, filename):
         """


### PR DESCRIPTION
If release-notes-sles is existed then it is not openSUSE Factory but
SLE, hence do not check totest and openSUSE-release.rpm on it.

And add try/except protection in get_binary_version otherwise it will
crashes in case the package is not existed.