### PR TITLE
Add --split argument to adi command

### DIFF
--- a/osc-staging.py
+++ b/osc-staging.py
@@ -67,6 +67,8 @@ def _full_project_name(self, project):
               help='force the selection to become a move')
 @cmdln.option('--by-develproject', action='store_true',
               help='sort the packages by devel project')
+@cmdln.option('--split', action='store_true',
+              help='splits each package to different adi staging')
 @cmdln.option('--supersede', action='store_true',
               help='superseding requests. please make sure you have staging permissions')
 @cmdln.option('-f', '--from', dest='from_', metavar='FROMPROJECT',
@@ -233,6 +235,6 @@ def do_staging(self, subcmd, opts, *args):
         elif cmd == 'list':
             ListCommand(api).perform(args[1:], supersede=opts.supersede)
         elif cmd == 'adi':
-            AdiCommand(api).perform(args[1:], move=opts.move, by_dp=opts.by_develproject)
+            AdiCommand(api).perform(args[1:], move=opts.move, by_dp=opts.by_develproject, split=opts.split)
         elif cmd == 'repair':
             RepairCommand(api).perform(args[1:])

--- a/osclib/adi_command.py
+++ b/osclib/adi_command.py
@@ -93,7 +93,7 @@ class AdiCommand:
                     # request_id pretended to be index of non_ring_requests
                     non_ring_requests[request_id] = [request_id]
                 else:
-                    if by_dp is True:
+                    if by_dp:
                         devel_project = self.get_devel_project(source_project, source_package)
                         # try target pacakge in Factory
                         # this is a bit against Leap development in case submissions is from Update,
@@ -103,7 +103,7 @@ class AdiCommand:
                         if devel_project is not None:
                             source_project = devel_project
 
-                    if not source_project in non_ring_requests:
+                    if source_project not in non_ring_requests:
                         non_ring_requests[source_project] = []
                     non_ring_requests[source_project].append(request_id)
                 
@@ -144,4 +144,4 @@ class AdiCommand:
         else:
             self.check_adi_projects() 
             if self.api.is_user_member_of(self.api.user, 'factory-staging'):
-                self.create_new_adi((), by_dp, split=split)
+                self.create_new_adi((), by_dp=by_dp, split=split)

--- a/osclib/adi_command.py
+++ b/osclib/adi_command.py
@@ -48,7 +48,7 @@ class AdiCommand:
         else:
             return node.get('project')
 
-    def create_new_adi(self, wanted_requests, by_dp=False):
+    def create_new_adi(self, wanted_requests, by_dp=False, split=False):
         all_requests = self.api.get_open_requests()
 
         non_ring_packages = []
@@ -89,19 +89,23 @@ class AdiCommand:
                     continue
 
                 non_ring_packages.append(target_package)
-                if by_dp is True:
-                    devel_project = self.get_devel_project(source_project, source_package)
-                    # try target pacakge in Factory
-                    # this is a bit against Leap development in case submissions is from Update,
-                    # or any other project than Factory
-                    if devel_project is None and self.api.project.startswith('openSUSE:'):
-                        devel_project = self.get_devel_project('openSUSE:Factory', target_package)
-                    if devel_project is not None:
-                        source_project = devel_project
+                if split:
+                    # request_id pretended to be index of non_ring_requests
+                    non_ring_requests[request_id] = [request_id]
+                else:
+                    if by_dp is True:
+                        devel_project = self.get_devel_project(source_project, source_package)
+                        # try target pacakge in Factory
+                        # this is a bit against Leap development in case submissions is from Update,
+                        # or any other project than Factory
+                        if devel_project is None and self.api.project.startswith('openSUSE:'):
+                            devel_project = self.get_devel_project('openSUSE:Factory', target_package)
+                        if devel_project is not None:
+                            source_project = devel_project
 
-                if not source_project in non_ring_requests:
-                    non_ring_requests[source_project] = []
-                non_ring_requests[source_project].append(request_id)
+                    if not source_project in non_ring_requests:
+                        non_ring_requests[source_project] = []
+                    non_ring_requests[source_project].append(request_id)
                 
         if len(non_ring_packages):
             print "Not in a ring:", ' '.join(sorted(non_ring_packages))
@@ -118,7 +122,7 @@ class AdiCommand:
             # Notify everybody about the changes
             self.api.update_status_comments(name, 'select')
 
-    def perform(self, packages, move=False, by_dp=False):
+    def perform(self, packages, move=False, by_dp=False, split=False):
         """
         Perform the list command
         """
@@ -136,8 +140,8 @@ class AdiCommand:
 
             for request, request_project in items:
                 requests.add(request)
-            self.create_new_adi(requests)
+            self.create_new_adi(requests, split=split)
         else:
             self.check_adi_projects() 
             if self.api.is_user_member_of(self.api.user, 'factory-staging'):
-                self.create_new_adi((), by_dp)
+                self.create_new_adi((), by_dp, split=split)


### PR DESCRIPTION
With --split argument, staging adi command can splits each package to different adi staging project, the argument can work by 'osc staging adi --split' or 'osc staging adi --move --split'. Note that, it will be
ignore --by-develproject argument too.