### PR TITLE
Accept cleanup

### DIFF
--- a/osc-staging.py
+++ b/osc-staging.py
@@ -85,6 +85,8 @@ def _full_project_name(self, project):
               help='show version of the plugin')
 @cmdln.option('--no-freeze', dest='no_freeze', action='store_true',
               help='force the select command ignoring the time from the last freeze')
+@cmdln.option('--no-cleanup', dest='no_cleanup', action='store_true',
+              help='do not cleanup remaining packages in staging projects after accept')
 def do_staging(self, subcmd, opts, *args):
     """${cmd_name}: Commands to work with staging projects
 
@@ -215,6 +217,9 @@ def do_staging(self, subcmd, opts, *args):
                     for prj in args[1:]:
                         if not cmd.perform(api.prj_from_letter(prj)):
                             return
+                        if not opts.no_cleanup:
+                            cmd.cleanup(api.prj_from_letter(prj))
+                            cmd.cleanup("%s:DVD" % api.prj_from_letter(prj))
                     cmd.accept_other_new()
                     cmd.update_factory_version()
                     if api.item_exists(api.crebuild):

--- a/osclib/accept_command.py
+++ b/osclib/accept_command.py
@@ -5,6 +5,7 @@ from xml.etree import cElementTree as ET
 
 from osc.core import change_request_state
 from osc.core import http_GET, http_PUT, http_DELETE
+from osc.core import delete_package
 from datetime import date
 from osclib.comments import CommentAPI
 
@@ -84,6 +85,16 @@ class AcceptCommand(object):
         if self.api.item_exists(project + ':DVD'):
             self.api.build_switch_prj(project + ':DVD', 'disable')
 
+        return True
+
+    def cleanup(self, project):
+        pkgs_to_keep = ['Test-DVD-x86_64', 'Test-DVD-ppc64le', 'bootstrap-copy']
+        pkglist = self.api.list_packages(project)
+        clean_list = set(pkglist) - set(pkgs_to_keep)
+
+        for package in clean_list:
+            print "[cleanup] deleted %s/%s" % (project, package)
+            delete_package(self.api.apiurl, project, package, force=True, msg="autocleanup")
         return True
 
     def accept_other_new(self):

--- a/osclib/stagingapi.py
+++ b/osclib/stagingapi.py
@@ -1145,19 +1145,19 @@ class StagingAPI(object):
                 return True
         return False
 
-    def check_pkgs(self, rebuild_list):
-        url = self.makeurl(['source', self.project])
+    def list_packages(self, project):
+        url = self.makeurl(['source', project])
         pkglist = []
 
         root = ET.parse(http_GET(url)).getroot()
-
         xmllines = root.findall("./entry")
-
         for pkg in xmllines:
-            if pkg.attrib['name'] in rebuild_list:
-                pkglist.append(pkg.attrib['name'])
+            pkglist.append(pkg.attrib['name'])
 
         return pkglist
+
+    def check_pkgs(self, rebuild_list):
+        return list(set(rebuild_list) & set(self.list_packages(self.project)))
 
     def rebuild_pkg(self, package, prj, arch, code=None):
         query = {


### PR DESCRIPTION
This changes 'osc staging accept' to remove any left packages in the staging projects.

it can be skipped by 'osc staging accept --no-cleanup'

It helps us not having to run after all stagings all the time and it intentionally prints the list of what it removed, as often we make use of this to know what we need to link additionally to rings.