### PR TITLE
list_packages: Return empty list if project does not exist

### DIFF
--- a/osclib/stagingapi.py
+++ b/osclib/stagingapi.py
@@ -1149,10 +1149,11 @@ class StagingAPI(object):
         url = self.makeurl(['source', project])
         pkglist = []
 
-        root = ET.parse(http_GET(url)).getroot()
-        xmllines = root.findall("./entry")
-        for pkg in xmllines:
-            pkglist.append(pkg.attrib['name'])
+        if self.item_exists(project):
+            root = ET.parse(http_GET(url)).getroot()
+            xmllines = root.findall("./entry")
+            for pkg in xmllines:
+                pkglist.append(pkg.attrib['name'])
 
         return pkglist
 


### PR DESCRIPTION
@coolo without further info from you, I think this should fix issues you might have on SP2, where there is no :DVD subproject in the staging areas

Care to test and confirm?