### PR TITLE
Accept: fix escaping when creating linked package

### DIFF
--- a/osclib/accept_command.py
+++ b/osclib/accept_command.py
@@ -148,7 +148,7 @@ class AcceptCommand(object):
                                      r'\1{}'.format(package),
                                      origmeta)
                     newmeta = re.sub(r'<devel.*>',
-                                     r'<devel package=\'{}\'/>'.format(pkgname),
+                                     r'<devel package="{}"/>'.format(pkgname),
                                      newmeta)
                     newmeta = re.sub(r'<bcntsynctag>.*</bcntsynctag>',
                                      r'',


### PR DESCRIPTION
Since we recently fixed the regex to actually match when to add the devel prj, it now shows that the devel prj we insert is invalid (it is added in the escaped form... \; is not being written as '.

Just use ' for the outer limits and " inside the xml limits... makes it more readable anyway (and works)