### PR TITLE
Use newcand param make sure don't select the processed requests

### DIFF
--- a/osclib/select_command.py
+++ b/osclib/select_command.py
@@ -125,7 +125,11 @@ class SelectCommand(object):
             return False
             # FreezeCommand(self.api).perform(self.target_project)
 
-        for request in RequestFinder.find_sr(requests, self.api):
+        # picks new candidate requests only if it's not to move requests
+        # ie. the review state of staging-project must be new if newcand is True
+        newcand = not move
+
+        for request in RequestFinder.find_sr(requests, self.api, newcand):
             if not self.select_request(request, move, from_):
                 return False
 


### PR DESCRIPTION
Scenario: the accepted request from adi staging what was queued for next Factory check-in round, if executing staging select command against a PROJECT , the processed request will picks up by staging tool again. So use 'newcand' param ensure staging-group's review state is new if selecting a PROJECT unless 'mov'e param is show up.