### PR TITLE
Hard require inkscape due to the pattern change

### DIFF
--- a/create_test_Factory_dvd-2.testcase
+++ b/create_test_Factory_dvd-2.testcase
@@ -30,6 +30,7 @@ job install name openSUSE-release-livecd-x11
 job install name sudo
 job install name xdelta
 job install name kate
+job install name inkscape
 job install name sddm
 job install name gnome-music
 job install name kexec-tools


### PR DESCRIPTION
Inkscape now are Suggests in the pattern rather than Recommends, hard require it in the staging DVD instead of drop the test from openQA.

Already applied it in the packagelists actually.