### PR TITLE
Prevent 13.1 review on maintenance submissions for packages dropped from Factory

### DIFF
--- a/check_maintenance_incidents.py
+++ b/check_maintenance_incidents.py
@@ -78,6 +78,9 @@ class MaintenanceChecker(ReviewBot.ReviewBot):
             if ((prj, pkg) in package_reviews):
                 self.logger.debug("%s/%s already is a reviewer, not adding again" % (prj, pkg))
                 continue
+            if prj == 'openSUSE:13.1:Update':
+                self.logger.debug("Package dropped from Factory, not adding review for %s/%s" % (prj, pkg))
+                continue
             self.add_review(req, by_project = prj, by_package = pkg,
                     msg = "Submission by someone who is not maintainer in the devel project. Please review")
 


### PR DESCRIPTION
Prevent 13.1 review on maintenance submissions for packages dropped from Factory.

This is due to `search/owner` falling back to Evergreen for a dropped package.

    $ osc api 'search/owner?binary=libotr2
    <collection>
    <owner rootproject="openSUSE" project="openSUSE:13.1:Update">
        <person name="xxx" role="maintainer"/>
        <group name="maintenance-opensuse.org" role="maintainer"/>
        <person name="xxx" role="bugowner"/>
        <group name="maintenance-opensuse.org" role="bugowner"/>
      </owner>
    </collection>
