### PR TITLE
Do not regenerate pl if the testdvd build is disabled

### DIFF
--- a/create_test_dvds.sh
+++ b/create_test_dvds.sh
@@ -149,6 +149,12 @@ function start_creating() {
 
             for prj in $projects; do
                 l=$(echo $prj | sed 's/^openSUSE.\+[:]Staging/Staging/g' | cut -d: -f2)
+                # if the testdvd build is disabled, do not regenerate the pacakges list and go to next staging project
+                testdvd_disabled=$(osc api "/build/openSUSE:$target:Staging:$l/_result?view=summary&package=Test-DVD-$arch&repository=images" | grep 'statuscount code="disabled"')
+                if [ -n "$testdvd_disabled" ]; then
+                    continue
+                fi
+
                 if [[ $prj =~ ^openSUSE.+:[A-Z]$ ]]; then
                     echo "Checking $target:$l-$arch"
 


### PR DESCRIPTION
Support of https://github.com/openSUSE/osc-plugin-factory/pull/593 in the create_test_dvds