### PR TITLE
Enhance ReviewBot based tools to work across build service instances.

### DIFF
--- a/check_maintenance_incidents.py
+++ b/check_maintenance_incidents.py
@@ -53,12 +53,12 @@ class MaintenanceChecker(ReviewBot.ReviewBot):
         query = {
             'binary': package,
         }
-        url = osc.core.makeurl(self.apiurl, ('search', 'owner'), query=query)
+        url = osc.core.makeurl(self.apiurl(), ('search', 'owner'), query=query)
         root = ET.parse(osc.core.http_GET(url)).getroot()
         maintainers = [p.get('name') for p in root.findall('.//person') if p.get('role') == 'maintainer']
         if not maintainers:
             for group in [p.get('name') for p in root.findall('.//group') if p.get('role') == 'maintainer']:
-                url = osc.core.makeurl(self.apiurl, ('group', group))
+                url = osc.core.makeurl(self.apiurl(), ('group', group))
                 root = ET.parse(osc.core.http_GET(url)).getroot()
                 maintainers = maintainers + [p.get('userid') for p in root.findall('./person/person')]
         return maintainers
@@ -68,7 +68,7 @@ class MaintenanceChecker(ReviewBot.ReviewBot):
         query = {
             'binary': package,
         }
-        url = osc.core.makeurl(self.apiurl, ('search', 'owner'), query=query)
+        url = osc.core.makeurl(self.apiurl(), ('search', 'owner'), query=query)
         root = ET.parse(osc.core.http_GET(url)).getroot()
 
         package_reviews = set((r.by_project, r.by_package) for r in req.reviews if r.by_project)
@@ -117,7 +117,7 @@ class MaintenanceChecker(ReviewBot.ReviewBot):
             project = a.tgt_project
 
         if project.startswith('openSUSE:Leap:'):
-            mapping = MaintenanceChecker._get_lookup_yml(self.apiurl, project)
+            mapping = MaintenanceChecker._get_lookup_yml(self.apiurl(project), project)
             if mapping is None:
                 self.logger.error("error loading mapping for {}".format(project))
             elif not pkgname in mapping:
@@ -210,7 +210,8 @@ class CommandLineInterface(ReviewBot.CommandLineInterface):
         return MaintenanceChecker(apiurl = apiurl, \
                 dryrun = self.options.dry, \
                 user = user, \
-                logger = self.logger)
+                logger = self.logger, \
+                apiurl_default = self.apiurl_default)
 
 if __name__ == "__main__":
     app = CommandLineInterface()

--- a/check_tags_in_requests.py
+++ b/check_tags_in_requests.py
@@ -75,15 +75,15 @@ by OBS on which this bot relies on.
 
     def isNewPackage(self, tgt_project, tgt_package):
         try:
-            self.logger.debug("package_meta %s %s/%s" % (self.apiurl, tgt_project, tgt_package))
-            osc.core.show_package_meta(self.apiurl, tgt_project, tgt_package)
+            self.logger.debug("package_meta %s %s/%s" % (self.apiurl(tgt_project), tgt_project, tgt_package))
+            osc.core.show_package_meta(self.apiurl(tgt_project), tgt_project, tgt_package)
         except (HTTPError, URLError):
             return True
         return False
 
     def checkTagInRequest(self, req, a):
         is_new = False
-        u = osc.core.makeurl(self.apiurl,
+        u = osc.core.makeurl(self.apiurl(a.tgt_project),
                              ['source', a.tgt_project, a.tgt_package],
                              {'cmd': 'diff',
                               'onlyissues': '1',
@@ -112,7 +112,7 @@ by OBS on which this bot relies on.
 
     def checkTagNotRequired(self, req, a):
         # if there is no diff, no tag is required
-        diff = osc.core.request_diff(self.apiurl, req.reqid)
+        diff = osc.core.request_diff(self.apiurl(), req.reqid)
         if not diff:
             return True
 
@@ -120,12 +120,13 @@ by OBS on which this bot relies on.
         # already in Factory with the same revision,
         # and the package is being introduced, not updated
         # 2) A new package must be have a issue tag
-        factory_checker = check_source_in_factory.FactorySourceChecker(apiurl=self.apiurl,
+        factory_checker = check_source_in_factory.FactorySourceChecker(apiurl=self._apiurl,
                                                                        dryrun=self.dryrun,
                                                                        logger=self.logger,
                                                                        user=self.review_user,
                                                                        group=self.review_group,
-                                                                       factory=self.factory)
+                                                                       factory=self.factory,
+                                                                       apiurl_default=self._apiurl_default)
         factory_ok = factory_checker.check_source_submission(a.src_project, a.src_package, a.src_rev,
                                                              a.tgt_project, a.tgt_package)
         return factory_ok
@@ -173,7 +174,8 @@ class CommandLineInterface(ReviewBot.CommandLineInterface):
                           factory=self.options.factory,
                           dryrun=self.options.dry,
                           group=self.options.group,
-                          logger=self.logger)
+                          logger=self.logger, \
+                          apiurl_default = self.apiurl_default)
 
 if __name__ == "__main__":
     app = CommandLineInterface()


### PR DESCRIPTION
Additionally, `manager_42.py` is updated in order to generate `lookup.yml` across instances as well.

To use simply set the `--apiurl` (`-A`) option to `htts://api.suse.de` (or configured alias) given configured `osc` access. This would benefit from further testing by those more familiar with the abilities and edge-cases of the affected tools

If one includes the `--debug` option the `apiurl` switches will be indicated. The switches are performed based on the relevant project where applicable. All comments, and context-less `request` API calls use the base URL which is the one passed on command line.

For example,
```bash
# sr#125153 is assumed to be on IBS
./leaper.py --verbose --debug --dry --apiurl ibs id 125153

# sr#445436 is assumed to be on OBS
./leaper.py --verbose --debug --dry id 445436

# will start on IBS and witch to OBS following history
./manager_42.py --debug --dry --apiurl ibs -f SUSE:SLE-12:Update kernel-source
```

It attempts to load the lookup maps for SLE (added fail handling since they are not present yet) and does a very basic check against `SUSE:SLE-12-SP2:Update` if base URL is IBS. This can be expanded in followup requests (perhaps by those a bit more familiar with the expected workflow). Otherwise, I believe it accomplishes the goal, but as stated I can only run the changes in a limited fashion.