### PR TITLE
Rework ReviewBot.CommandLineInterface to provide class option.

### DIFF
--- a/ReviewBot.py
+++ b/ReviewBot.py
@@ -351,6 +351,7 @@ class ReviewBot(object):
 class CommandLineInterface(cmdln.Cmdln):
     def __init__(self, *args, **kwargs):
         cmdln.Cmdln.__init__(self, args, kwargs)
+        self.clazz = ReviewBot
 
     def get_optparser(self):
         parser = cmdln.Cmdln.get_optparser(self)
@@ -395,7 +396,6 @@ class CommandLineInterface(cmdln.Cmdln):
 
     def setup_checker(self):
         """ reimplement this """
-
         apiurl = osc.conf.config['apiurl']
         if apiurl is None:
             raise osc.oscerr.ConfigError("missing apiurl")
@@ -405,7 +405,7 @@ class CommandLineInterface(cmdln.Cmdln):
         if user is None and group is None:
             user = osc.conf.get_apiurl_usr(apiurl)
 
-        return ReviewBot(apiurl = apiurl, \
+        return self.clazz(apiurl = apiurl, \
                 dryrun = self.options.dry, \
                 user = user, \
                 group = group, \

--- a/abichecker/abichecker.py
+++ b/abichecker/abichecker.py
@@ -171,18 +171,10 @@ class ABIChecker(ReviewBot.ReviewBot):
     """
 
     def __init__(self, *args, **kwargs):
+        ReviewBot.ReviewBot.__init__(self, *args, **kwargs)
+
         self.no_review = False
         self.force = False
-        if 'no_review' in kwargs:
-            if kwargs['no_review'] == True:
-                self.no_review = True
-            del kwargs['no_review']
-        if 'force' in kwargs:
-            if kwargs['force'] == True:
-                self.force = True
-            del kwargs['force']
-
-        ReviewBot.ReviewBot.__init__(self, *args, **kwargs)
 
         self.ts = rpm.TransactionSet()
         self.ts.setVSFlags(rpm._RPMVSF_NOSIGNATURES)
@@ -1061,6 +1053,7 @@ class CommandLineInterface(ReviewBot.CommandLineInterface):
 
     def __init__(self, *args, **kwargs):
         ReviewBot.CommandLineInterface.__init__(self, args, kwargs)
+        self.clazz = ABIChecker
 
     def get_optparser(self):
         parser = ReviewBot.CommandLineInterface.get_optparser(self)
@@ -1080,20 +1073,14 @@ class CommandLineInterface(ReviewBot.CommandLineInterface):
         return ret
 
     def setup_checker(self):
+        bot = ReviewBot.CommandLineInterface.setup_checker(self)
 
-        apiurl = osc.conf.config['apiurl']
-        if apiurl is None:
-            raise osc.oscerr.ConfigError("missing apiurl")
-        user = self.options.user
-        if user is None:
-            user = osc.conf.get_apiurl_usr(apiurl)
+        if self.options.no_review:
+            bot.no_review = True
+        if self.options.force:
+            bot.force = True
 
-        return ABIChecker(apiurl = apiurl, \
-                dryrun = self.options.dry, \
-                no_review = self.options.no_review, \
-                user = user, \
-                force = self.options.force, \
-                logger = self.logger)
+        return bot
 
     @cmdln.option('-r', '--revision', metavar="number", type="int", help="revision number")
     def do_diff(self, subcmd, opts, src_project, src_package, dst_project, dst_package):

--- a/check_maintenance_incidents.py
+++ b/check_maintenance_incidents.py
@@ -193,27 +193,9 @@ class MaintenanceChecker(ReviewBot.ReviewBot):
 
         return ret
 
-class CommandLineInterface(ReviewBot.CommandLineInterface):
-
-    def __init__(self, *args, **kwargs):
-        ReviewBot.CommandLineInterface.__init__(self, args, kwargs)
-
-    def setup_checker(self):
-
-        apiurl = osc.conf.config['apiurl']
-        if apiurl is None:
-            raise osc.oscerr.ConfigError("missing apiurl")
-        user = self.options.user
-        if user is None:
-            user = osc.conf.get_apiurl_usr(apiurl)
-
-        return MaintenanceChecker(apiurl = apiurl, \
-                dryrun = self.options.dry, \
-                user = user, \
-                logger = self.logger)
-
 if __name__ == "__main__":
-    app = CommandLineInterface()
+    app = ReviewBot.CommandLineInterface()
+    app.clazz = MaintenanceChecker
     sys.exit( app.main() )
 
 # vim: sw=4 et

--- a/check_source_in_factory.py
+++ b/check_source_in_factory.py
@@ -44,13 +44,8 @@ class FactorySourceChecker(ReviewBot.ReviewBot):
     request is reviewed positive."""
 
     def __init__(self, *args, **kwargs):
-        self.factory = None
-        if 'factory' in kwargs:
-            self.factory = kwargs['factory']
-            del kwargs['factory']
-        if self.factory is None:
-            self.factory = "openSUSE:Factory"
         ReviewBot.ReviewBot.__init__(self, *args, **kwargs)
+        self.factory = "openSUSE:Factory"
         self.review_messages = { 'accepted' : 'ok', 'declined': 'the package needs to be accepted in Factory first' }
         self.lookup = {}
 
@@ -181,6 +176,7 @@ class CommandLineInterface(ReviewBot.CommandLineInterface):
 
     def __init__(self, *args, **kwargs):
         ReviewBot.CommandLineInterface.__init__(self, args, kwargs)
+        self.clazz = FactorySourceChecker
 
     def get_optparser(self):
         parser = ReviewBot.CommandLineInterface.get_optparser(self)
@@ -190,20 +186,10 @@ class CommandLineInterface(ReviewBot.CommandLineInterface):
         return parser
 
     def setup_checker(self):
+        bot = ReviewBot.CommandLineInterface.setup_checker(self)
 
-        apiurl = osc.conf.config['apiurl']
-        if apiurl is None:
-            raise osc.oscerr.ConfigError("missing apiurl")
-        user = self.options.user
-        if user is None:
-            user = osc.conf.get_apiurl_usr(apiurl)
-
-        bot = FactorySourceChecker(apiurl = apiurl, \
-                factory = self.options.factory, \
-                dryrun = self.options.dry, \
-                user = user, \
-                logger = self.logger)
-
+        if self.options.factory:
+            bot.factory = self.options.factory
         if self.options.lookup:
             bot.parse_lookup(self.options.lookup)
 

--- a/leaper.py
+++ b/leaper.py
@@ -416,6 +416,7 @@ class CommandLineInterface(ReviewBot.CommandLineInterface):
 
     def __init__(self, *args, **kwargs):
         ReviewBot.CommandLineInterface.__init__(self, args, kwargs)
+        self.clazz = Leaper
 
     def get_optparser(self):
         parser = ReviewBot.CommandLineInterface.get_optparser(self)
@@ -427,21 +428,7 @@ class CommandLineInterface(ReviewBot.CommandLineInterface):
         return parser
 
     def setup_checker(self):
-
-        apiurl = osc.conf.config['apiurl']
-        if apiurl is None:
-            raise osc.oscerr.ConfigError("missing apiurl")
-        user = self.options.user
-        group = self.options.group
-        # if no args are given, use the current oscrc "owner"
-        if user is None and group is None:
-            user = osc.conf.get_apiurl_usr(apiurl)
-
-        bot = Leaper(apiurl = apiurl, \
-                dryrun = self.options.dry, \
-                user = user, \
-                group = group, \
-                logger = self.logger)
+        bot = ReviewBot.CommandLineInterface.setup_checker(self)
 
         if self.options.manual_version_updates:
             bot.must_approve_version_updates = True


### PR DESCRIPTION
Alleviates the need for a lot of duplicate code, some of which is already out-of-sync. Some examples of out-of-sync code are as follows.

- `check_source_in_factory.py`: not include group parameter
- `check_tags_in_requests.py`: missing default user

Either way this is primarily intended as a cleanup. I ran into this when I started porting `osc-check_source.py` to `ReviewBot` and needed to copy/paste a bunch of code for no good reason.