### PR TITLE
leaper.py: indicate if origin differs from the expected origin.

### DIFF
--- a/leaper.py
+++ b/leaper.py
@@ -135,7 +135,9 @@ class Leaper(ReviewBot.ReviewBot):
         is_fine_if_factory = False
         not_in_factory_okish = False
         if origin:
-            self.logger.info("expected origin is '%s'", origin)
+            origin_same = src_project.startswith(origin)
+            self.logger.info("expected origin is '%s' (%s)", origin,
+                             "unchanged" if origin_same else "changed")
             if origin.startswith('Devel;'):
                 (dummy, origin, dummy) = origin.split(';')
                 if origin != src_project:
@@ -164,7 +166,7 @@ class Leaper(ReviewBot.ReviewBot):
                 if self.must_approve_maintenance_updates:
                     self.needs_release_manager = True
                 # submitted from :Update
-                if src_project.startswith(origin):
+                if origin_same:
                     self.logger.debug("submission from 42.2 ok")
                     return True
                 # switching to sle package might make sense


### PR DESCRIPTION
Minor and perhaps others have a better idea for wording, but I find myself squinting to see if the origin has changed when reading the comment.

Example output:
```
INFO:leaper.py:checking 448728
INFO:leaper.py:SUSE:SLE-12-SP2:Update/libzypp.3458@6256a456cdd115084ec37121e16af717 -> openSUSE:Leap:42.3/libzypp
INFO:leaper.py:expected origin is 'SUSE:SLE-12-SP2:Update' (unchanged)
```

Could make it more like a sentence: `origin matches the expected origin '...'` and `origin (does not match|differs from) the expected origin '...'`.