### PR TITLE
Correct indentation level of in requests_ignored check.

### DIFF
--- a/osclib/list_command.py
+++ b/osclib/list_command.py
@@ -87,8 +87,8 @@ class ListCommand:
                     elif source_prj.startswith('home:'):
                         source_prj = '~' + source_prj[len('home:'):]
                     result[devel][-1] += ' ({})'.format(source_prj)
-                    if request_id in requests_ignored:
-                        result[devel][-1] += '\nignored: ' + requests_ignored[request_id]
+                if request_id in requests_ignored:
+                    result[devel][-1] += '\nignored: ' + requests_ignored[request_id]
             else:
                 non_ring_packages.append(target_package)
 


### PR DESCRIPTION
In the previous state this worked for any project except factory, now it works on factory too.

I normally avoid running commands against factory, but given `list` makes no changes it should be fine. Anyway, I seem to have been focused on ensuring the `\n` was added after
```python
result[devel][-1] += ' ({})'.format(source_prj)
```
that I included the check in

```python
if self.api.project != "openSUSE:Factory" and action.find('source') != None:
```

which clearly would not work for factory. Glad to see @DimStar77 already tried to use it though. ;)