### PR TITLE
RequestSplitter and staging selection proposals

### DIFF
--- a/osc-staging.py
+++ b/osc-staging.py
@@ -14,10 +14,14 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+from __future__ import print_function
+
 import os
 import os.path
 import sys
+import tempfile
 import warnings
+import yaml
 
 from osc import cmdln
 from osc import oscerr
@@ -40,6 +44,7 @@ from osclib.stagingapi import StagingAPI
 from osclib.cache import Cache
 from osclib.unselect_command import UnselectCommand
 from osclib.repair_command import RepairCommand
+from osclib.request_splitter import RequestSplitter
 
 OSC_STAGING_VERSION = '0.0.1'
 
@@ -95,6 +100,9 @@ def _full_project_name(self, project):
 @cmdln.option('--wipe-cache', dest='wipe_cache', action='store_true', default=False,
               help='wipe GET request cache before executing')
 @cmdln.option('-m', '--message', help='message used by ignore command')
+@cmdln.option('--filter-by', action='append', help='xpath by which to filter requests')
+@cmdln.option('--group-by', action='append', help='xpath by which to group requests')
+@cmdln.option('-i', '--interactive', action='store_true', help='interactively modify selection proposal')
 def do_staging(self, subcmd, opts, *args):
     """${cmd_name}: Commands to work with staging projects
 
@@ -125,6 +133,53 @@ def do_staging(self, subcmd, opts, *args):
     "list" will pick the requests not in rings
 
     "select" will add requests to the project
+        Stagings are expected to be either in short-hand or the full project
+        name. For example letter or named stagings can be specified simply as
+        A, B, Gcc6, etc, while adi stagings can be specified as adi:1, adi:2,
+        etc. Currently, adi stagings are not supported in proposal mode.
+
+        Requests may either be the target package or the request ID.
+
+        When using --filter-by or --group-by the xpath will be applied to the
+        request node as returned by OBS. Several values will supplement the
+        normal request node.
+
+        - ./action/source/@devel_project: the devel project for the package
+        - ./action/target/@ring: the ring to which the package belongs
+        - ./@ignored: either false or the provided message
+
+        Some useful examples:
+
+        --filter-by './action/target[starts-with(@package, "yast-")]'
+        --filter-by './action/source/[@devel_project="YaST:Head"]'
+        --filter-by './action/target[starts-with(@ring, "1")]'
+        --filter-by '@id!="1234567"'
+
+        --group-by='./action/source/@devel_project'
+        --group-by='./action/target/@ring'
+
+        Multiple filter-by or group-by options may be used at the same time.
+
+        Note that when using proposal mode, multiple stagings to consider may be
+        provided in addition to a list of requests by which to filter. A more
+        complex example:
+
+        select --group-by='./action/source/@devel_project' A B C 123 456 789
+
+        This will separate the requests 123, 456, 789 by devel project and only
+        consider stagings A, B, or C, if available, for placement.
+
+        No arguments is also a valid choice and will propose all non-ignored
+        requests into the first available staging. Note that bootstrapped
+        stagings are only used when either required or no other stagings are
+        available.
+
+        Another useful example is placing all open requests into a specific
+        letter staging with:
+
+        select A
+
+        Interactive mode allows the proposal to be modified before application.
 
     "unselect" will remove from the project - pushing them back to the backlog
 
@@ -137,7 +192,8 @@ def do_staging(self, subcmd, opts, *args):
         osc staging ignore [-m MESSAGE] REQUEST...
         osc staging unignore REQUEST...|all
         osc staging list [--supersede]
-        osc staging select [--no-freeze] [--move [--from PROJECT]] LETTER REQUEST...
+        osc staging select [--no-freeze] [--move [--from PROJECT] STAGING REQUEST...
+        osc staging select [--no-freeze] [[--interactive] [--filter-by...] [--group-by...]] [STAGING...] [REQUEST...]
         osc staging unselect REQUEST...
         osc staging repair REQUEST...
     """
@@ -153,9 +209,7 @@ def do_staging(self, subcmd, opts, *args):
     elif cmd == 'check':
         min_args, max_args = 0, 2
     elif cmd == 'select':
-        min_args, max_args = 1, None
-        if not opts.add:
-            min_args = 2
+        min_args, max_args = 0, None
     elif cmd == 'unselect':
         min_args, max_args = 1, None
     elif cmd == 'adi':
@@ -236,12 +290,104 @@ def do_staging(self, subcmd, opts, *args):
         elif cmd == 'unselect':
             UnselectCommand(api).perform(args[1:])
         elif cmd == 'select':
-            tprj = api.prj_from_letter(args[1])
-            if opts.add:
-                api.mark_additional_packages(tprj, [opts.add])
+            # Include list of all stagings in short-hand and by full name.
+            existing_stagings = api.get_staging_projects_short(None)
+            existing_stagings += [p for p in api.get_staging_projects() if not p.endswith(':DVD')]
+            stagings = []
+            requests = []
+            for arg in args[1:]:
+                # Since requests may be given by either request ID or package
+                # name and stagings may include multi-letter special stagings
+                # there is no easy way to distinguish between stagings and
+                # requests in arguments. Therefore, check if argument is in the
+                # list of short-hand and full project name stagings, otherwise
+                # consider it a request. This also allows for special stagings
+                # with the same name as package, but the staging will be assumed
+                # first time around. The current practice seems to be to start a
+                # special staging with a capital letter which makes them unique.
+                # lastly adi stagings are consistently prefix with adi: which
+                # also makes it consistent to distinguish them from request IDs.
+                if arg in existing_stagings and arg not in stagings:
+                    stagings.append(api.extract_staging_short(arg))
+                elif arg not in requests:
+                    requests.append(arg)
+
+            if len(stagings) != 1 or len(requests) == 0 or opts.filter_by or opts.group_by:
+                if opts.move or opts.from_:
+                    print('--move and --from must be used with explicit staging and request list')
+                    return
+
+                splitter = RequestSplitter(api, api.get_open_requests(), in_ring=True)
+                if len(requests) > 0:
+                    splitter.filter_add_requests(requests)
+                if len(splitter.filters) == 0:
+                    splitter.filter_add('./action[not(@type="add_role" or @type="change_devel")]')
+                    splitter.filter_add('@ignored="false"')
+                if opts.filter_by:
+                    for filter_by in opts.filter_by:
+                        splitter.filter_add(filter_by)
+                if opts.group_by:
+                    for group_by in opts.group_by:
+                        splitter.group_by(group_by)
+                splitter.split()
+
+                result = splitter.propose_assignment(stagings)
+                if result is not True:
+                    print('Failed to generate proposal: {}'.format(result))
+                    return
+                proposal = splitter.proposal
+                if len(proposal) == 0:
+                    print('Empty proposal')
+                    return
+
+                if opts.interactive:
+                    with tempfile.NamedTemporaryFile(suffix='.yml') as temp:
+                        temp.write(yaml.safe_dump(splitter.proposal, default_flow_style=False) + '\n\n')
+                        temp.write('# move requests between stagings or comment/remove them\n')
+                        temp.write('# change the target staging for a group\n')
+                        temp.write('# stagings\n')
+                        temp.write('# - considered: {}\n'
+                                   .format(', '.join(sorted(splitter.stagings_considerable.keys()))))
+                        temp.write('# - available: {}\n'
+                                   .format(', '.join(sorted(splitter.stagings_available.keys()))))
+                        temp.flush()
+
+                        editor = os.getenv('EDITOR')
+                        if not editor:
+                            editor = 'xdg-open'
+                        return_code = subprocess.call([editor, temp.name])
+
+                        proposal = yaml.safe_load(open(temp.name).read())
+
+                print(yaml.safe_dump(proposal, default_flow_style=False))
+
+                print('Accept proposal? [y/n] (y): ', end='')
+                response = raw_input().lower()
+                if response != '' and response != 'y':
+                    print('Quit')
+                    return
+
+                for group in sorted(proposal.keys()):
+                    g = proposal[group]
+                    if not g['requests']:
+                        # Skipping since all request removed, presumably in interactive.
+                        continue
+
+                    print('Staging {}'.format(g['staging']))
+
+                    # SelectCommand expects strings.
+                    request_ids = map(str, g['requests'].keys())
+                    target_project = api.prj_from_short(g['staging'])
+
+                    SelectCommand(api, target_project) \
+                        .perform(request_ids, opts.move, opts.from_, opts.no_freeze)
             else:
-                SelectCommand(api, tprj).perform(args[2:], opts.move,
-                                                 opts.from_, opts.no_freeze)
+                target_project = api.prj_from_short(stagings[0])
+                if opts.add:
+                    api.mark_additional_packages(target_project, [opts.add])
+                else:
+                    SelectCommand(api, target_project) \
+                        .perform(requests, opts.move, opts.from_, opts.no_freeze)
         elif cmd == 'cleanup_rings':
             CleanupRings(api).perform()
         elif cmd == 'ignore':

--- a/osc-staging.py
+++ b/osc-staging.py
@@ -194,16 +194,16 @@ def do_staging(self, subcmd, opts, *args):
                 FreezeCommand(api).perform(api.prj_from_letter(prj), copy_bootstrap = opts.bootstrap )
         elif cmd == 'frozenage':
             for prj in args[1:]:
-                print "%s last frozen %0.1f days ago" % (api.prj_from_letter(prj), api.days_since_last_freeze(api.prj_from_letter(prj)))
+                print("%s last frozen %0.1f days ago" % (api.prj_from_letter(prj), api.days_since_last_freeze(api.prj_from_letter(prj))))
         elif cmd == 'acheck':
             # Is it safe to accept? Meaning: /totest contains what it should and is not dirty
             version_totest = api.get_binary_version(api.project, "openSUSE-release.rpm", repository="totest", arch="x86_64")
             if version_totest:
                 version_openqa = api.load_file_content("%s:Staging" % api.project, "dashboard", "version_totest")
                 totest_dirty = api.is_repo_dirty(api.project, 'totest')
-                print "version_openqa: %s / version_totest: %s / totest_dirty: %s\n" % (version_openqa, version_totest, totest_dirty)
+                print("version_openqa: %s / version_totest: %s / totest_dirty: %s\n" % (version_openqa, version_totest, totest_dirty))
             else:
-                print "acheck is unavailable in %s!\n" % (api.project)
+                print("acheck is unavailable in %s!\n" % (api.project))
         elif cmd == 'accept':
             # Is it safe to accept? Meaning: /totest contains what it should and is not dirty
             version_totest = api.get_binary_version(api.project, "openSUSE-release.rpm", repository="totest", arch="x86_64")
@@ -232,7 +232,7 @@ def do_staging(self, subcmd, opts, *args):
                     if api.item_exists(api.crebuild):
                         cmd.sync_buildfailures()
             else:
-                print "Not safe to accept: /totest is not yet synced"
+                print("Not safe to accept: /totest is not yet synced")
         elif cmd == 'unselect':
             UnselectCommand(api).perform(args[1:])
         elif cmd == 'select':

--- a/osclib/list_command.py
+++ b/osclib/list_command.py
@@ -1,7 +1,16 @@
 from osc import oscerr
+from osclib.request_splitter import RequestSplitter
 
 
 class ListCommand:
+    SOURCE_PROJECT_STRIP = [
+        'SUSE:SLE-12:',
+        'SUSE:SLE-12-',
+        'openSUSE:Leap:'
+        'openSUSE:',
+        'home:',
+    ]
+
     def __init__(self, api):
         self.api = api
 
@@ -20,86 +29,68 @@ class ListCommand:
                 # First dispatch all possible requests
                 self.api.dispatch_open_requests()
 
-        # Print out the left overs
         requests = self.api.get_open_requests()
         requests_ignored = self.api.get_ignored_requests()
 
-        non_ring_packages = []
-        change_devel_requests = {}
+        splitter = RequestSplitter(self.api, requests, in_ring=True)
+        splitter.filter_add('./action[@type="change_devel"]')
+        change_devel_requests = splitter.filter_only()
+        splitter.reset()
 
-        result = {}
-        for request in requests:
-            # Consolidate all data from request
-            request_id = int(request.get('id'))
-            action = request.findall('action')
-            if not action:
-                msg = 'Request {} has no action'.format(request_id)
-                raise oscerr.WrongArgs(msg)
-            # we care only about first action
-            action = action[0]
+        splitter.filter_add('./action[not(@type="add_role" or @type="change_devel")]')
+        splitter.group_by('./action/source/@devel_project')
+        splitter.split()
 
-            # Where are we targeting the package
-            target_package = action.find('target').get('package')
+        is_factory = self.api.project != 'openSUSE:Factory'
+        for group in sorted(splitter.grouped.keys()):
+            print group
 
-            # ignore add_role requests
-            if action.get('type') == 'add_role':
-                continue
+            for request in splitter.grouped[group]['requests']:
+                request_id = int(request.get('id'))
+                action = request.find('action')
+                target_package = action.find('target').get('package')
+                ring = action.find('target').get('ring')
+                if self.api.crings and ring is None:
+                    ring = self.api.project
+                if action.get('type') == 'delete':
+                    if ring:
+                        ring += ' (delete request)'
+                    else:
+                        ring = '(delete request)'
 
-            # handle change_devel requests
-            if action.get('type') == 'change_devel':
-                change_devel_requests[target_package] = request_id
-                continue
+                line = 'sr#{}: {:<30} -> {:<12}'.format(request_id, target_package, ring)
 
-            # If the system have rings, we ask for the ring of the
-            # package
-            if self.api.crings:
-                ring = self.api.ring_packages_for_links.get(target_package)
-                if ring:
-                    # cut off *:Rings: prefix
-                    ring = ring[len(self.api.crings)+1:]
-            else:
-                ring = self.api.project
+                if is_factory and action.find('source') != None:
+                    source_project = action.find('source').get('project')
+                    source_project = self.project_strip(source_project)
+                    line += ' ({})'.format(source_project)
 
-            # list all deletereq as in-ring
-            if action.get('type') == 'delete':
-                if ring:
-                    ring = ring + " (delete request)"
-                else:
-                    ring = '(delete request)'
-
-            # This condition is quite moot as we dispatched stuff
-            # above anyway
-            if ring:
-                devel = self.api.get_devel_project("openSUSE:Factory", target_package)
-                if devel is None:
-                    devel = '00'
-                result.setdefault(devel, []).append('sr#{}: {:<30} -> {:<12}'.format(request_id, target_package, ring))
-                # show origin of request
-                if self.api.project != "openSUSE:Factory" and action.find('source') != None:
-                    source_prj = action.find('source').get('project')
-                    if source_prj.startswith('SUSE:SLE-12:') \
-                        or source_prj.startswith('SUSE:SLE-12-'):
-                        source_prj = source_prj[len('SUSE:SLE-12:'):]
-                    elif source_prj.startswith('openSUSE:'):
-                        source_prj = source_prj[len('openSUSE:'):]
-                        if source_prj.startswith('Leap:'):
-                            source_prj = source_prj[len('Leap:'):]
-                    elif source_prj.startswith('home:'):
-                        source_prj = '~' + source_prj[len('home:'):]
-                    result[devel][-1] += ' ({})'.format(source_prj)
                 if request_id in requests_ignored:
-                    result[devel][-1] += '\nignored: ' + requests_ignored[request_id]
-            else:
-                non_ring_packages.append(target_package)
+                    line += '\n    ignored: ' + requests_ignored[request_id]
 
-        for prj in sorted(result.keys()):
-            print prj
-            for line in result[prj]:
-                print ' ', line.replace('\n', '\n    ')
+                print ' ', line
 
-        if len(non_ring_packages):
-            print "Not in a ring:", ' '.join(sorted(non_ring_packages))
+        if len(splitter.other):
+            non_ring_packages = []
+            for request in splitter.other:
+                non_ring_packages.append(request.find('./action/target').get('package'))
+            print 'Not in a ring:', ' '.join(sorted(non_ring_packages))
+
         if len(change_devel_requests):
-            print "\nChange devel requests:"
-            for package, requestid in change_devel_requests.items():
-                print('Request({}): {}'.format(package, 'https://build.opensuse.org/request/show/'+str(requestid)))
+            print '\nChange devel requests:'
+            for request in change_devel_requests:
+                target_package = request.find('./action/target').get('package')
+                url = self.api.makeurl(['request', 'show', request.get('id')])
+                print('- request({}): {}'.format(target_package, url))
+
+    def project_strip(self, source_project):
+        home = source_project.startswith('home:')
+
+        for prefix in self.SOURCE_PROJECT_STRIP:
+            if source_project.startswith(prefix):
+                source_project = source_project[len(prefix):]
+
+        if home:
+            source_project = '~' + source_project
+
+        return source_project

--- a/osclib/request_splitter.py
+++ b/osclib/request_splitter.py
@@ -1,0 +1,113 @@
+from lxml import etree as ET
+
+class RequestSplitter(object):
+    def __init__(self, api, requests, in_ring):
+        self.api = api
+        self.requests = requests
+        self.in_ring = in_ring
+        self.requests_ignored = self.api.get_ignored_requests()
+        self.reset()
+
+    def reset(self):
+        self.filters = []
+        self.groups = []
+
+        # after split()
+        self.filtered = []
+        self.other = []
+        self.grouped = {}
+
+    def filter_add(self, xpath):
+        self.filters.append(ET.XPath(xpath))
+
+    def filter_add_requests(self, requests):
+        requests = ' ' + ' '.join(requests) + ' '
+        self.filter_add('contains("{requests}", concat(" ", @id, " ")) or '
+                        'contains("{requests}", concat(" ", ./action/target/@package, " "))'
+                        .format(requests=requests))
+
+    def group_by(self, xpath):
+        self.groups.append(ET.XPath(xpath))
+
+    def filter_only(self):
+        ret = []
+        for request in self.requests:
+            target_package = request.find('./action/target').get('package')
+            self.suppliment(request, target_package)
+            if self.filter_check(request):
+                ret.append(request)
+        return ret
+
+    def split(self):
+        for request in self.requests:
+            target_package = request.find('./action/target').get('package')
+            self.suppliment(request, target_package)
+
+            if not self.filter_check(request):
+                continue
+
+            if self.in_ring != (not self.api.ring_packages.get(target_package)):
+                # Request is of desired ring type.
+                key = self.group_key_build(request)
+                if key not in self.grouped:
+                    self.grouped[key] = {
+                        'bootstrap_required': False,
+                        'requests': [],
+                    }
+
+                self.grouped[key]['requests'].append(request)
+
+                ring = request.find('./action/target').get('ring')
+                if ring and ring.startswith('0'):
+                    self.grouped[key]['bootstrap_required'] = True
+            else:
+                self.other.append(request)
+
+    def suppliment(self, request, target_package):
+        """ Provide additional information for grouping """
+        devel = self.devel_project_get(request, target_package)
+        if devel:
+            request.find('./action/source').set('devel_project', devel)
+
+        ring = self.ring_get(target_package)
+        if ring:
+            request.find('./action/target').set('ring', ring)
+
+        request_id = int(request.get('id'))
+        if request_id in self.requests_ignored:
+            request.set('ignored', self.requests_ignored[request_id])
+        else:
+            request.set('ignored', 'false')
+
+    def ring_get(self, target_package):
+        if self.api.crings:
+            ring = self.api.ring_packages_for_links.get(target_package)
+            if ring:
+                # Cut off *:Rings: prefix.
+                return ring[len(self.api.crings)+1:]
+        return None
+
+    def devel_project_get(self, request, target_project):
+        # Preserve logic from adi and note that not Leap development friendly.
+        source = request.find('./action/source')
+        devel = self.api.get_devel_project(source.get('project'), source.get('package'))
+        if devel is None and self.api.project.startswith('openSUSE:'):
+            devel = self.api.get_devel_project('openSUSE:Factory', target_project)
+        return devel
+
+    def filter_check(self, request):
+        for xpath in self.filters:
+            if not xpath(request):
+                return False
+        return True
+
+    def group_key_build(self, request):
+        if len(self.groups) == 0:
+            return 'all'
+
+        key = []
+        for xpath in self.groups:
+            element = xpath(request)
+            if element:
+                key.append(element[0])
+        return '__'.join(key)

--- a/osclib/stagingapi.py
+++ b/osclib/stagingapi.py
@@ -541,6 +541,11 @@ class StagingAPI(object):
             #     self.accept_non_ring_request(rq)
             self.update_superseded_request(rq, packages)
 
+    def get_prj_meta(self, project):
+        url = make_meta_url('prj', project, self.apiurl)
+        f = http_GET(url)
+        return ET.parse(f).getroot()
+
     @memoize(ttl=60, session=True, add_invalidate=True)
     def get_prj_pseudometa(self, project):
         """
@@ -549,9 +554,7 @@ class StagingAPI(object):
         :return structured object with metadata
         """
 
-        url = make_meta_url('prj', project, self.apiurl)
-        f = http_GET(url)
-        root = ET.parse(f).getroot()
+        root = self.get_prj_meta(project)
         description = root.find('description')
         # If YAML parsing fails, load default
         # FIXME: Better handling of errors

--- a/osclib/stagingapi.py
+++ b/osclib/stagingapi.py
@@ -314,6 +314,34 @@ class StagingAPI(object):
             projects.append(val.get('name'))
         return projects
 
+    def extract_staging_short(self, p):
+        if not ':' in p:
+            return p
+        prefix = len(self.cstaging) + 1
+        if p.endswith(':DVD'):
+            p = p[:-4]
+        return p[prefix:]
+
+    def prj_from_short(self, name):
+        if name.startswith(self.cstaging):
+            return name
+        return '{}:{}'.format(self.cstaging, name)
+
+    def get_staging_projects_short(self, adi=False):
+        """
+        Get list of staging project by short-hand names.
+        :param adi: True for only adi stagings, False for only non-adi stagings,
+                    and None for both.
+        """
+        prefix = len(self.cstaging) + 1
+        projects = []
+        for project in self.get_staging_projects():
+            if project.endswith(':DVD') or \
+               (adi is not None and self.is_adi_project(project) != adi):
+                continue
+            projects.append(self.extract_staging_short(project))
+        return projects
+
     def is_adi_project(self, p):
         return ':adi:' in p
 

--- a/osclib/stagingapi.py
+++ b/osclib/stagingapi.py
@@ -1030,7 +1030,7 @@ class StagingAPI(object):
         prjmeta = ET.parse(http_GET(url)).getroot()
 
         flagxml = prjmeta.find(flag)
-        if not flagxml:  # appending is fine
+        if flagxml is None:
             flagxml = ET.SubElement(prjmeta, flag)
 
         foundone = False

--- a/osclib/stagingapi.py
+++ b/osclib/stagingapi.py
@@ -19,7 +19,7 @@ import logging
 import urllib2
 import time
 import re
-from xml.etree import cElementTree as ET
+from lxml import etree as ET
 
 import yaml
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+lxml
 PyYAML
 pycurl
 urlgrabber

--- a/tests/api_tests.py
+++ b/tests/api_tests.py
@@ -242,7 +242,7 @@ class TestApiCalls(unittest.TestCase):
 
         self.api.create_package_container('openSUSE:Factory:Staging:B', 'wine', disable_build=True)
         self.assertEqual(httpretty.last_request().method, 'PUT')
-        self.assertEqual(httpretty.last_request().body, '<package name="wine"><title /><description /><build><disable /></build></package>')
+        self.assertEqual(httpretty.last_request().body, '<package name="wine"><title/><description/><build><disable/></build></package>')
         self.assertEqual(httpretty.last_request().path, '/source/openSUSE:Factory:Staging:B/wine/_meta')
 
     def test_review_handling(self):


### PR DESCRIPTION
While working on `openSUSE:Leap:42.3` I have maintained a few local wrapper scripts to assist in some of the staging work. With the addition of #631 proposals would not include undesired requests and so I decided to build out what I had been thinking about.

The goal is threefold:
1) replace `list` and `adi` parts with a common request filter/group code base
2) utilize such a framework for adding filter/group capability to select command
3) lay the groundwork for potential future work in creating higher level select strategies to fully automate the process as much as possible

I believe the first two are achieved quite well by this and much of the third.

The following is taken from the included documentation.
```
When using --filter-by or --group-by the xpath will be applied to the
request node as returned by OBS. Several values will supplement the
normal request node.

- ./action/source/@devel_project: the devel project for the package
- ./action/target/@ring: the ring to which the package belongs
- ./@ignored: either false or the provided message

Some useful examples:

--filter-by './action/target[starts-with(@package, "yast-"]'
--filter-by './action/source/[@devel_project="YaST:Head"]'
--filter-by './action/target[@ring="1-MinimalX"]'

--group-by='./action/source/@devel_project'
--group-by='./action/target/@ring'

Note that when using proposal mode multiple letter stagings to consider
may be provided in addition to a list of request IDs by which to filter.
A more complex example:

select --group-by='./action/source/@devel_project' A B C 123 456 789

This will separate the requests 123, 456, 789 by devel project and only
consider stagings A, B, or C, if available, for placement.

No arguments is also a valid choice and will propose all non-ignored
requests into the first available staging. Note that bootstrapped
stagings are only used when either required or no other stagings are
available.

Another useful example is placing all open requests into a specific
letter staging with:

select A

Interactive mode allows the proposal to be modified before application.
```

Hopefully, from that you have some ideas on how to utilize this.

The included `--interactive` flag provides an interactive mode for changing the proposal in a similar fashion to `git rebase -i`. This is rather slick and allows for easy proposal cleanup or just always use and start from scratch as it is fairly easy to move requests around how ever desired rather then coming up with a full list for manual `select` commands.

One note is that `lxml` is required in order to have more fully-featured `xpath` expressions. With that in mind there are obviously more possibilities than those listed in the documentation (like regular expressions). I will be playing with this to ensure everything works as this replaces quite a lot of existing functionality so hold off accepting. That said I would appreciate feedback and testing. The `adi` and `list` commands are a fair bit easier to read and understand as I see it and can be expanded to expose the additional filter/group by functionality if desired. I believe after the last round of changes there may be some things I can further strip out of those two files as well.

I made the last set of staging selections for `openSUSE:Leap:42.3` using a generated proposal. :)

Have fun.