### PR TITLE
Enhance fallback-onfail review mode

### DIFF
--- a/ReviewBot.py
+++ b/ReviewBot.py
@@ -115,21 +115,22 @@ class ReviewBot(object):
 
         by_user = self.fallback_user
         by_group = self.fallback_group
+        msg = self.review_messages.get(state, state)
 
         if state == 'declined':
             if self.review_mode == 'fallback-onfail':
                 self.logger.info("%s needs fallback reviewer"%req.reqid)
                 # don't check duplicates, in case review was re-opened
-                self.add_review(req, by_group=by_group, by_user=by_user)
-                newstate = 'accepted'
+                msg = self.review_messages.get('fallback', 'ReviewBot Failed. Please Review')
+                self.add_review(req, by_group=by_group, by_user=by_user, msg=msg)
+                doit = None
         elif self.review_mode == 'fallback-always':
             self.add_review(req, by_group=by_group, by_user=by_user)
 
-        msg = self.review_messages[state] if state in self.review_messages else state
         self.logger.info("%s %s: %s"%(req.reqid, state, msg))
 
         if doit == True:
-            self.logger.debug("setting %s to %s"%(req.reqid, state))
+            self.logger.debug("setting %s to %s"%(req.reqid, newstate))
             if not self.dryrun:
                 osc.core.change_review_state(apiurl = self.apiurl,
                         reqid = req.reqid, newstate = newstate,

--- a/check_source_in_factory.py
+++ b/check_source_in_factory.py
@@ -46,7 +46,10 @@ class FactorySourceChecker(ReviewBot.ReviewBot):
     def __init__(self, *args, **kwargs):
         ReviewBot.ReviewBot.__init__(self, *args, **kwargs)
         self.factory = "openSUSE:Factory"
-        self.review_messages = { 'accepted' : 'ok', 'declined': 'the package needs to be accepted in Factory first' }
+        self.review_messages = { 'accepted': 'ok',
+                                 'declined': 'the package needs to be accepted in Factory first',
+                                 'fallback': 'Sources not accepted in Factory. Please review.',
+                                 }
         self.lookup = {}
 
     def reset_lookup(self):


### PR DESCRIPTION
- Add message when setting fallback reviewer indicating the
  ReviewBot failure
- Do NOT set review to "accepted". Nothing has been "accepted" yet;
  just delegated to human review.
- Fixed debug output (state should be newstate)