### PR TITLE
osc-check_repo.py: alter http cache directory due to box constraints.

### DIFF
--- a/osc-check_repo.py
+++ b/osc-check_repo.py
@@ -36,9 +36,13 @@ sys.path.append(PLUGINDIR)
 from osclib.conf import Config
 from osclib.checkrepo import CheckRepo
 from osclib.checkrepo import BINCACHE, DOWNLOADS
+from osclib.cache import Cache
 from osclib.cycle import CycleDetector
 from osclib.memoize import CACHEDIR
+from osclib.memoize import save_cache_path
 from osclib.request_finder import RequestFinder
+
+Cache.CACHE_DIR = save_cache_path('opensuse-repo-checker-http')
 
 
 def _check_repo_download(self, request):


### PR DESCRIPTION
As noted in https://github.com/openSUSE/osc-plugin-factory/pull/629#issuecomment-274010120 the machine used to run the `osc-check_repo.py` script does not have write access to `~/.cache`. I copied the style that is already working, but this can obviously be set to anything.