### PR TITLE
staging adi: provide --open-review-by and --loop-when-reviewed options.

### DIFF
--- a/osc-staging.py
+++ b/osc-staging.py
@@ -103,6 +103,8 @@ def _full_project_name(self, project):
 @cmdln.option('--filter-by', action='append', help='xpath by which to filter requests')
 @cmdln.option('--group-by', action='append', help='xpath by which to group requests')
 @cmdln.option('-i', '--interactive', action='store_true', help='interactively modify selection proposal')
+@cmdln.option('--open-review-by', metavar='GROUP', help='open request (xdg-open) when relevant review matches')
+@cmdln.option('--loop-when-reviewed', action='store_true', help='loop when a request was opened for review')
 def do_staging(self, subcmd, opts, *args):
     """${cmd_name}: Commands to work with staging projects
 
@@ -185,6 +187,7 @@ def do_staging(self, subcmd, opts, *args):
 
     Usage:
         osc staging accept [--force] [LETTER...]
+        osc staging adi [--by-develproject] [--open-review-by GROUP [--loop-when-reviewed]]
         osc staging check [--old] REPO
         osc staging cleanup_rings
         osc staging freeze [--no-boostrap] PROJECT...
@@ -397,6 +400,6 @@ def do_staging(self, subcmd, opts, *args):
         elif cmd == 'list':
             ListCommand(api).perform(args[1:], supersede=opts.supersede)
         elif cmd == 'adi':
-            AdiCommand(api).perform(args[1:], move=opts.move, by_dp=opts.by_develproject, split=opts.split)
+            AdiCommand(api).perform(args[1:], move=opts.move, by_dp=opts.by_develproject, split=opts.split, open_review_by=opts.open_review_by, loop_when_reviewed=opts.loop_when_reviewed)
         elif cmd == 'repair':
             RepairCommand(api).perform(args[1:])


### PR DESCRIPTION
Together these options help increase the efficiency of adi reviews by opening requests that are waiting on reviews by the specified group so the user can review them. When combined with loop option all pending reviews can be opened and stagings marked ready.

As noted in the comment this does not handle all possible future workflows and may need tweaking as it stands. I'd like to start a discussion about defining the workflows used in the various projects so things like the list of bots that should be considered blocking before prioritizing human review and the release manager related groups that should be opened for reviews can be placed in config files rather than loads of command line arguments that will need to differ for each staging.

For Leap the workflow looks like:
- pending leaper (which may be a while as it waits for Factory acceptance)
- leap-reviewers once leaper has accepted
- auto open requests and loop which will eventually make it through any adi stagings that are blocked by leap-reviewers
- final loop marks requests as ready to accept and deletes adi stagings
- last iteration also stages new requests

This is another on of the things I have been using in a wrapper script for months and I find rather useful. If this approach is too simplistic and would rather wait for a more exhaustive one that may make sense, but hopefully it can be of use in this state.