### PR TITLE
stagingapi: Avoid search/package query to determine devel project.

### DIFF
--- a/ReviewBot.py
+++ b/ReviewBot.py
@@ -320,8 +320,9 @@ class ReviewBot(object):
             node = ET.fromstring(''.join(m)).find('devel')
             if node is not None:
                 return node.get('project'), node.get('package', None)
-        except urllib2.HTTPError:
-            pass
+        except urllib2.HTTPError, e:
+            if e.code == 404:
+                pass
         return None, None
 
     def can_accept_review(self, request_id):

--- a/osclib/stagingapi.py
+++ b/osclib/stagingapi.py
@@ -1326,41 +1326,13 @@ class StagingAPI(object):
         else:
             return False
 
-    # from manager_42
-    def _fill_package_meta(self, project):
-        self._package_metas.setdefault(project, {})
-        url = makeurl(self.apiurl, ['search', 'package'], "match=[@project='%s']" % project)
-        root = ET.parse(self.retried_GET(url))
-        for p in root.findall('package'):
-            name = p.attrib['name']
-            self._package_metas[project][name] = p
-
-
-    def _get_devel_project(self, project, package):
-        """ get devel project for a single project"""
-        if not self.item_exists(project, package):
-            return None
-
-        m = show_package_meta(self.apiurl, project, package)
-        node = ET.fromstring(''.join(m)).find('devel')
-        if node is None:
-            return None
-        else:
-            return node.get('project')
-
     def get_devel_project(self, project, package):
-        # if _package_metas is None we force individual queries
-        if self._package_metas is None:
-            return self._get_devel_project(project,package)
-
-        if not project in self._package_metas:
-            self._fill_package_meta(project)
-
-        if not package in self._package_metas[project]:
-            return None
-
-        node = self._package_metas[project][package].find('devel')
-        if node is None:
-            return None
-
-        return node.get('project')
+        try:
+            m = show_package_meta(self.apiurl, project, package)
+            node = ET.fromstring(''.join(m)).find('devel')
+            if node is not None:
+                return node.get('project')
+        except urllib2.HTTPError, e:
+            if e.code == 404:
+                pass
+        return None


### PR DESCRIPTION
The search/package query is typically very slow and can spend several minutes timing out. The concept of loading all package meta data at once is attractive, but given that the query regularly increases the runtime of the script by an order of magnitude or more making individual calls seems advantageous. These calls are already included in the cache which means the initial request avoids the 10+ minute wait and repetitive calls have no additional cost.

I ran into this query failing >5 times today and have been considering this change for a while. In the `check_source.py` port I changed to query for individual packages since it should requests as they come and would not see much benefit from loading all package data at once. See [ReviewBot.get_devel_project()](https://github.com/openSUSE/osc-plugin-factory/blob/master/ReviewBot.py#L317).

I see factory averages >50 packages in backlog which will be roughly the number of calls made during a `list` call. Leap 42.3 had ~25 packages in backlog when I took a look. I ran staging commands using this change and worked as expected. Definitely a trade off, but I think in general this will be far more consistent (generally does not timeout) and relatively quick response per query.