### PR TITLE
Added X11:Solus to the Factory devel project whitelist

### DIFF
--- a/check_source.whitelist
+++ b/check_source.whitelist
@@ -13,3 +13,4 @@ server:messaging
 system:snappy
 X11:GNUstep
 FATE
+X11:Solus


### PR DESCRIPTION
To resolve the error at https://build.opensuse.org/request/show/452889 Not sure if this is correct. I guess https://en.opensuse.org/openSUSE:How_to_contribute_to_Factory#How_to_request_a_new_devel_project needs an update.