### PR TITLE
Remove source devel project check carried over from flawed adi logic

### DIFF
--- a/osc-staging.py
+++ b/osc-staging.py
@@ -144,18 +144,18 @@ def do_staging(self, subcmd, opts, *args):
         request node as returned by OBS. Several values will supplement the
         normal request node.
 
-        - ./action/source/@devel_project: the devel project for the package
+        - ./action/target/@devel_project: the devel project for the package
         - ./action/target/@ring: the ring to which the package belongs
         - ./@ignored: either false or the provided message
 
         Some useful examples:
 
         --filter-by './action/target[starts-with(@package, "yast-")]'
-        --filter-by './action/source/[@devel_project="YaST:Head"]'
+        --filter-by './action/target/[@devel_project="YaST:Head"]'
         --filter-by './action/target[starts-with(@ring, "1")]'
         --filter-by '@id!="1234567"'
 
-        --group-by='./action/source/@devel_project'
+        --group-by='./action/target/@devel_project'
         --group-by='./action/target/@ring'
 
         Multiple filter-by or group-by options may be used at the same time.
@@ -164,7 +164,7 @@ def do_staging(self, subcmd, opts, *args):
         provided in addition to a list of requests by which to filter. A more
         complex example:
 
-        select --group-by='./action/source/@devel_project' A B C 123 456 789
+        select --group-by='./action/target/@devel_project' A B C 123 456 789
 
         This will separate the requests 123, 456, 789 by devel project and only
         consider stagings A, B, or C, if available, for placement.

--- a/osclib/adi_command.py
+++ b/osclib/adi_command.py
@@ -58,7 +58,7 @@ class AdiCommand:
             if split:
                 splitter.group_by('./@id')
             elif by_dp:
-                splitter.group_by('./action/source/@devel_project')
+                splitter.group_by('./action/target/@devel_project')
             else:
                 splitter.group_by('./action/source/@project')
         splitter.split()

--- a/osclib/list_command.py
+++ b/osclib/list_command.py
@@ -38,7 +38,7 @@ class ListCommand:
         splitter.reset()
 
         splitter.filter_add('./action[not(@type="add_role" or @type="change_devel")]')
-        splitter.group_by('./action/source/@devel_project')
+        splitter.group_by('./action/target/@devel_project')
         splitter.split()
 
         is_factory = self.api.project != 'openSUSE:Factory'

--- a/osclib/request_splitter.py
+++ b/osclib/request_splitter.py
@@ -70,7 +70,7 @@ class RequestSplitter(object):
         target_project = request.find('./action/target').get('project')
         devel = self.devel_project_get(target_project, target_package)
         if devel:
-            request.find('./action/source').set('devel_project', devel)
+            request.find('./action/target').set('devel_project', devel)
 
         ring = self.ring_get(target_package)
         if ring:

--- a/osclib/request_splitter.py
+++ b/osclib/request_splitter.py
@@ -34,20 +34,19 @@ class RequestSplitter(object):
     def filter_only(self):
         ret = []
         for request in self.requests:
-            target_package = request.find('./action/target').get('package')
-            self.suppliment(request, target_package)
+            self.suppliment(request)
             if self.filter_check(request):
                 ret.append(request)
         return ret
 
     def split(self):
         for request in self.requests:
-            target_package = request.find('./action/target').get('package')
-            self.suppliment(request, target_package)
+            self.suppliment(request)
 
             if not self.filter_check(request):
                 continue
 
+            target_package = request.find('./action/target').get('package')
             if self.in_ring != (not self.api.ring_packages.get(target_package)):
                 # Request is of desired ring type.
                 key = self.group_key_build(request)
@@ -65,16 +64,18 @@ class RequestSplitter(object):
             else:
                 self.other.append(request)
 
-    def suppliment(self, request, target_package):
+    def suppliment(self, request):
         """ Provide additional information for grouping """
-        target_project = request.find('./action/target').get('project')
+        target = request.find('./action/target')
+        target_project = target.get('project')
+        target_package = target.get('package')
         devel = self.devel_project_get(target_project, target_package)
         if devel:
-            request.find('./action/target').set('devel_project', devel)
+            target.set('devel_project', devel)
 
         ring = self.ring_get(target_package)
         if ring:
-            request.find('./action/target').set('ring', ring)
+            target.set('ring', ring)
 
         request_id = int(request.get('id'))
         if request_id in self.requests_ignored:

--- a/osclib/request_splitter.py
+++ b/osclib/request_splitter.py
@@ -67,7 +67,8 @@ class RequestSplitter(object):
 
     def suppliment(self, request, target_package):
         """ Provide additional information for grouping """
-        devel = self.devel_project_get(request, target_package)
+        target_project = request.find('./action/target').get('project')
+        devel = self.devel_project_get(target_project, target_package)
         if devel:
             request.find('./action/source').set('devel_project', devel)
 
@@ -89,12 +90,10 @@ class RequestSplitter(object):
                 return ring[len(self.api.crings)+1:]
         return None
 
-    def devel_project_get(self, request, target_project):
-        # Preserve logic from adi and note that not Leap development friendly.
-        source = request.find('./action/source')
-        devel = self.api.get_devel_project(source.get('project'), source.get('package'))
+    def devel_project_get(self, target_project, target_package):
+        devel = self.api.get_devel_project(target_project, target_package)
         if devel is None and self.api.project.startswith('openSUSE:'):
-            devel = self.api.get_devel_project('openSUSE:Factory', target_project)
+            devel = self.api.get_devel_project('openSUSE:Factory', target_package)
         return devel
 
     def filter_check(self, request):


### PR DESCRIPTION
Followup on confirmation that previous adi logic was bad and some further testing.

- Remove incorrect devel project lookup copied from adi.
- Move @devel_project to action/target. 