### PR TITLE
Repochecker: add rpmlint-mini to the whitelist to not have an rpmlint.log

### DIFF
--- a/repo-checker.pl
+++ b/repo-checker.pl
@@ -50,6 +50,7 @@ for my $pdir ( glob("$dir/*") ) {
             || $name eq "rpm-python"
             || $name eq "popt"
             || $name eq "rpmlint"
+            || $name eq "rpmlint-mini"
             || $name eq "rpmlint-Factory" )
         {
             print "ignoring - whitelist\n";


### PR DESCRIPTION

Otherwise there is a bootstrap issue