### PR TITLE
ttm: Fix configuration for s390x

### DIFF
--- a/totest-manager.py
+++ b/totest-manager.py
@@ -490,7 +490,7 @@ class ToTestFactoryzSystems(ToTestBase):
         ToTestBase.__init__(self, *args, **kwargs)
 
     def openqa_group(self):
-        return 'openSUSE Tumbleweed zSystems'
+        return 'openSUSE Tumbleweed s390x'
 
     def arch(self):
         return 's390x'
@@ -499,7 +499,7 @@ class ToTestFactoryzSystems(ToTestBase):
         return 'Tumbleweed'
 
     def jobs_num(self):
-        return 4
+        return 1
 
 class ToTestFactoryARM(ToTestFactory):
     main_products = [ '_product:openSUSE-cd-mini-aarch64',


### PR DESCRIPTION
The openQA group has now been officially created and named slightly
different

Additionally, there is only one job being run at this moment: make
this sufficient for ttm to detect the snapshot being tested.