### PR TITLE
issue-diff: use bugowner or maintainer as assignee for bug (and small changes)

### DIFF
--- a/issue-diff.py
+++ b/issue-diff.py
@@ -26,7 +26,7 @@ from osclib.cache import Cache
 # unicode character in its summary.
 BUG_SUMMARY = 'Missing issue references from {project}/{package} in {factory}/{package}'
 BUG_TEMPLATE = u'{message_start}\n\n{issues}'
-MESSAGE_START = 'The following issues were referenced in the changelog for {project}/{package}, but where not found in {factory}/{package} after {newest} days. Review the issues and submit changes to {factory} as necessary.'
+MESSAGE_START = 'The following issues were referenced in the changelog for {project}/{package}, but where not found in {factory}/{package} after {newest} days. Review the issues and submit changes to {factory} to ensure all relevant changes end up in {factory} which is used as the basis for the next SLE version. For more information and details on how to go about submitting the changes see https://mailman.suse.de/mlarch/SuSE/research/2017/research.2017.02/msg00051.html.'
 ISSUE_SUMMARY = u'[{label}]({url}) owned by {owner}: {summary}'
 ISSUE_SUMMARY_PLAIN = u'[{label}]({url})'
 

--- a/issue-diff.py
+++ b/issue-diff.py
@@ -378,7 +378,7 @@ if __name__ == '__main__':
     parser.add_argument('--bugzilla-cc', metavar='EMAIL', help='bugzilla address added to cc on all bugs created')
     parser.add_argument('-d', '--debug', action='store_true', help='print info useful for debugging')
     parser.add_argument('-f', '--factory', default='openSUSE:Factory', metavar='PROJECT', help='factory project to use as baseline for comparison')
-    parser.add_argument('-p', '--project', default='SUSE:SLE-12-SP2:GA', metavar='PROJECT', help='project to check for issues that have are not found in factory')
+    parser.add_argument('-p', '--project', default='SUSE:SLE-12-SP3:GA', metavar='PROJECT', help='project to check for issues that have are not found in factory')
     parser.add_argument('--newest', type=int, default='30', metavar='AGE_IN_DAYS', help='newest issues to be considered')
     parser.add_argument('--limit', type=int, default='0', help='limit number of packages with new issues processed')
     parser.add_argument('--config-dir', help='configuration directory containing git-sync tool and issue db')


### PR DESCRIPTION
Re-initialized the issue-db repo and granted @coolo write access per discussion.

- update description to include a short reason.
- change default project to SLE-12-SP3.
- use bugowner or maintainer as assignee for bug.

Still not sure on what is desired for description text. @coolo: How wordy do you want it?