### PR TITLE
source-checker: handle add/remove changes files for patch diff check.

### DIFF
--- a/source-checker.pl
+++ b/source-checker.pl
@@ -200,7 +200,13 @@ if (-d "$old") {
     if (%patches) {
         # parsing changes
         for my $changes (@changes) {
-            my $diff = diff "$old/$changes", "$dir/$changes";
+            my $diff = "";
+            if (! -e "$old/$changes") {
+                $diff = diff "/dev/null", "$dir/$changes";
+            }
+            else {
+                $diff = diff "$old/$changes", "$dir/$changes";
+            }
             for my $line (split(/\n/, $diff)) {
                 next unless $line =~ m/^+/;
                 $line =~ s/^\+//;


### PR DESCRIPTION
See sr#455547 which now functions properly.

Before:
```
Output of check script:
No such file or directory: _old/u-boot-nanopineo.changes at /home/repochecker/src/osc-plugin-factory/source-checker.pl line 203.
```

After:
```
INFO:check_source.py:checking 455547
INFO:check_source.py:Base:System/u-boot@230 -> openSUSE:Factory/u-boot
INFO:check_source.py:POST https://api.opensuse.org/request/455547?by_group=None&cmd=addreview
INFO:check_source.py:POST https://api.opensuse.org/request/455547?cmd=addreview&by_user=factory-repo-checker                               
INFO:check_source.py:455547 accepted: Check script succeeded                                                                               
DEBUG:check_source.py:455547 review not changed
```