### PR TITLE
request_splitter: delete requests should always be considered in a ring.

### DIFF
--- a/osclib/request_splitter.py
+++ b/osclib/request_splitter.py
@@ -76,6 +76,9 @@ class RequestSplitter(object):
         ring = self.ring_get(target_package)
         if ring:
             target.set('ring', ring)
+        elif request.find('./action').get('type') == 'delete':
+            # Delete requests should always be considered in a ring.
+            target.set('ring', 'delete')
 
         request_id = int(request.get('id'))
         if request_id in self.requests_ignored:


### PR DESCRIPTION
An alternative approach to #671 which places delete request not otherwise in a ring in a fake ring "delete" since it is only used for filtering/grouping. Could place in an existing ring if desired, but this keeps it out of the adi list.