### PR TITLE
request_splitter: house keeping (and fix for SLE [non-ring] workflow)

### DIFF
--- a/osc-staging.py
+++ b/osc-staging.py
@@ -348,7 +348,7 @@ def do_staging(self, subcmd, opts, *args):
                         temp.write('# stagings\n')
                         temp.write('# - considered: {}\n'
                                    .format(', '.join(sorted(splitter.stagings_considerable.keys()))))
-                        temp.write('# - available: {}\n'
+                        temp.write('# - remaining: {}\n'
                                    .format(', '.join(sorted(splitter.stagings_available.keys()))))
                         temp.flush()
 

--- a/osclib/list_command.py
+++ b/osclib/list_command.py
@@ -50,13 +50,8 @@ class ListCommand:
                 action = request.find('action')
                 target_package = action.find('target').get('package')
                 ring = action.find('target').get('ring')
-                if self.api.crings and ring is None:
-                    ring = self.api.project
                 if action.get('type') == 'delete':
-                    if ring:
-                        ring += ' (delete request)'
-                    else:
-                        ring = '(delete request)'
+                    ring += ' (delete request)'
 
                 line = 'sr#{}: {:<30} -> {:<12}'.format(request_id, target_package, ring)
 

--- a/osclib/request_splitter.py
+++ b/osclib/request_splitter.py
@@ -75,6 +75,9 @@ class RequestSplitter(object):
         ring = self.ring_get(target_package)
         if ring:
             target.set('ring', ring)
+        elif request.find('./action').get('type') == 'delete':
+            # Delete requests should always be considered in a ring.
+            target.set('ring', 'delete')
 
         request_id = int(request.get('id'))
         if request_id in self.requests_ignored:

--- a/osclib/request_splitter.py
+++ b/osclib/request_splitter.py
@@ -46,8 +46,8 @@ class RequestSplitter(object):
             if not self.filter_check(request):
                 continue
 
-            target_package = request.find('./action/target').get('package')
-            if self.in_ring != (not self.api.ring_packages.get(target_package)):
+            ring = request.find('./action/target').get('ring')
+            if self.in_ring != (not ring):
                 # Request is of desired ring type.
                 key = self.group_key_build(request)
                 if key not in self.grouped:
@@ -58,7 +58,6 @@ class RequestSplitter(object):
 
                 self.grouped[key]['requests'].append(request)
 
-                ring = request.find('./action/target').get('ring')
                 if ring and ring.startswith('0'):
                     self.grouped[key]['bootstrap_required'] = True
             else:

--- a/osclib/request_splitter.py
+++ b/osclib/request_splitter.py
@@ -112,6 +112,8 @@ class RequestSplitter(object):
             element = xpath(request)
             if element:
                 key.append(element[0])
+        if len(key) == 0:
+            return '00'
         return '__'.join(key)
 
     def propose_stagings_load(self, stagings):

--- a/osclib/request_splitter.py
+++ b/osclib/request_splitter.py
@@ -88,6 +88,9 @@ class RequestSplitter(object):
             if ring:
                 # Cut off *:Rings: prefix.
                 return ring[len(self.api.crings)+1:]
+        else:
+            # Projects not using rings handle all requests as ring requests.
+            return self.api.project
         return None
 
     def devel_project_get(self, target_project, target_package):


### PR DESCRIPTION
- list: remove case for delete request without ring.
- non-ring projects consider all requests in rings.
- utilize ring attribute rather then lookup again.
- rather than an empty group name use 00.
