### PR TITLE
check_tags: warn when issue references are removed (plus other fixes)

### DIFF
--- a/check_tags_in_requests.py
+++ b/check_tags_in_requests.py
@@ -78,13 +78,13 @@ by OBS on which this bot relies on.
 
     def checkTagInRequest(self, req, a):
         u = osc.core.makeurl(self.apiurl,
-                             ['source', a.tgt_project, a.tgt_package],
+                             ['source', a.src_project, a.src_package],
                              {'cmd': 'diff',
                               'onlyissues': '1',
                               'view': 'xml',
-                              'opackage': a.src_package,
-                              'oproject': a.src_project,
-                              'orev': a.src_rev})
+                              'opackage': a.tgt_package,
+                              'oproject': a.tgt_project,
+                              'rev': a.src_rev})
         try:
             f = osc.core.http_POST(u)
         except (HTTPError, URLError):

--- a/check_tags_in_requests.py
+++ b/check_tags_in_requests.py
@@ -56,7 +56,7 @@ class TagChecker(ReviewBot.ReviewBot):
         super(TagChecker, self).__init__(*args, **kwargs)
         self.factory = "openSUSE:Factory"
         self.review_messages['declined'] = """
-(This is a script running, so report bugs)
+(This is a script, so report bugs)
 
 The project you submitted to requires a bug tracker ID marked in the
 .changes file. OBS supports several patterns, see
@@ -64,8 +64,8 @@ $ osc api /issue_trackers
 
 See also https://en.opensuse.org/openSUSE:Packaging_Patches_guidelines#Current_set_of_abbreviations
 
-Note that not necessarily all of the tags listed there are supported
-by OBS on which this bot relies on.
+Note that not all of the tags listed there are necessarily supported
+by OBS on which this bot relies.
 """
 
     def isNewPackage(self, tgt_project, tgt_package):
@@ -115,7 +115,7 @@ by OBS on which this bot relies on.
         # 1) A tag is not required only if the package is
         # already in Factory with the same revision,
         # and the package is being introduced, not updated
-        # 2) A new package must be have a issue tag
+        # 2) A new package must have an issue tag
         factory_checker = check_source_in_factory.FactorySourceChecker(apiurl=self.apiurl,
                                                                        dryrun=self.dryrun,
                                                                        logger=self.logger,

--- a/check_tags_in_requests.py
+++ b/check_tags_in_requests.py
@@ -97,9 +97,13 @@ by OBS on which this bot relies on.
 
         xml = ET.parse(f)
         issues = len(xml.findall('./issues/issue'))
+        removed = len(xml.findall('./issues/issue[@state="removed"]'))
         if issues == 0:
             self.logger.debug("reject: diff contains no tags")
             return False
+        if removed > 0:
+            self.review_messages['accepted'] = 'Warning: {} issues reference(s) removed'.format(removed)
+            return True
         return True
 
     def checkTagNotRequired(self, req, a):

--- a/check_tags_in_requests.py
+++ b/check_tags_in_requests.py
@@ -96,8 +96,8 @@ by OBS on which this bot relies on.
             return None
 
         xml = ET.parse(f)
-        has_changes = list(xml.findall('./issues/issue'))
-        if not has_changes:
+        issues = len(xml.findall('./issues/issue'))
+        if issues == 0:
             self.logger.debug("reject: diff contains no tags")
             return False
         return True

--- a/tests/checktags_tests.py
+++ b/tests/checktags_tests.py
@@ -163,12 +163,12 @@ Pico text editor while also offering a few enhancements.</description>
     def _run_with_data(self, accept, exists_in_factory, issues_data):
         # exists_in_factory: whether the package is exists in factory
         httpretty.register_uri(httpretty.POST,
-                               osc.core.makeurl(APIURL, ['source', "openSUSE:Factory", "nano"], {'cmd': 'diff',
+                               osc.core.makeurl(APIURL, ['source', "editors", "nano"], {         'cmd': 'diff',
                                                                                                  'onlyissues': '1',
                                                                                                  'view': 'xml',
                                                                                                  'opackage': 'nano',
-                                                                                                 'oproject': 'editors',
-                                                                                                 'orev': '25'}),
+                                                                                                 'oproject': 'openSUSE:Factory',
+                                                                                                 'rev': '25'}),
                                match_querystring=True,
                                body=issues_data)
         httpretty.register_uri(httpretty.GET,


### PR DESCRIPTION
Requested in #677.

- handle failed to load issue diff for existing package.
- correct backwards diff.
- use len() instead of list() since only count is of interest.
- **warn when issue references are removed.**
- grammatical corrections.

Interestingly enough the diff would appear to have been performed backwards. Since only the existence of issues was checked this worked fine, but given the request was about warning when removed it seemed proper to flip rather than look for `added` when meaning `deleted`.

For example, sr#455816 which is clearly adding one bug reference showed it as being `deleted`:

```xml
<sourcediff key="c9b42dc9c3a1f9435342cbe12cad4d3d">
  <old package="python3-requests.6329" project="openSUSE:Leap:42.2:Update" rev="baa02f86911ca86af78b4f0db1b7b882" srcmd5="baa02f86911ca86af78b4f0db1b7b882" />
  <new package="python3-requests" project="openSUSE:Leap:42.3" rev="4" srcmd5="1809a2399024102a6b19ea1ea83e79f2" />
  <files />
  <issues>
    <issue label="boo#912903" name="912903" state="deleted" tracker="bnc" url="https://bugzilla.opensuse.org/show_bug.cgi?id=912903" />
  </issues>
</sourcediff>
```

Whereas after reversing the diff:

```xml
<sourcediff key="148e0ab7e2d155c8933bd5d73d78691d">
  <old package="python3-requests" project="openSUSE:Leap:42.3" rev="4" srcmd5="1809a2399024102a6b19ea1ea83e79f2" />
  <new package="python3-requests.6329" project="openSUSE:Leap:42.2:Update" rev="baa02f86911ca86af78b4f0db1b7b882" srcmd5="baa02f86911ca86af78b4f0db1b7b882" />
  <files />
  <issues>
    <issue label="boo#912903" name="912903" state="added" tracker="bnc" url="https://bugzilla.opensuse.org/show_bug.cgi?id=912903" />
  </issues>
</sourcediff>
```