### PR TITLE
adi: map wanted_requests to str() before passing to splitter.

### DIFF
--- a/osclib/adi_command.py
+++ b/osclib/adi_command.py
@@ -52,7 +52,7 @@ class AdiCommand:
         splitter = RequestSplitter(self.api, requests, in_ring=False)
         splitter.filter_add('./action[@type="submit"]')
         if len(wanted_requests):
-            splitter.filter_add_requests(wanted_requests)
+            splitter.filter_add_requests([str(p) for p in wanted_requests])
             # wanted_requests forces all requests into a single group.
         else:
             if split:


### PR DESCRIPTION
Fixed #680.