### PR TITLE
check_source: allow self-submission.

### DIFF
--- a/check_source.py
+++ b/check_source.py
@@ -45,7 +45,9 @@ class CheckSource(ReviewBot.ReviewBot):
             # Check if target package exists and has devel project.
             devel_project, devel_package = self.get_devel_project(target_project, target_package)
             if devel_project:
-                if source_project != devel_project or source_package != devel_package:
+                if (source_project != devel_project or source_package != devel_package) and \
+                   not(source_project == target_project and source_package == target_package):
+                    # Not from proper devel project/package and not self-submission.
                     self.review_messages['declined'] = 'Expected submission from devel package %s/%s' % (devel_project, devel_package)
                     return False
             else:


### PR DESCRIPTION
Requested in #569. Using request provided as example (sr#428605).

Before:
```
INFO:check_source.py:checking 428605
INFO:check_source.py:openSUSE:Factory/translate-toolkit@17 -> openSUSE:Factory/translate-toolkit
INFO:check_source.py:428605 declined: Expected submission from devel package M17N/translate-toolkit
DEBUG:check_source.py:setting 428605 to declined
```

After:
```
INFO:check_source.py:checking 428605
INFO:check_source.py:openSUSE:Factory/translate-toolkit@17 -> openSUSE:Factory/translate-toolkit
INFO:check_source.py:POST https://api.opensuse.org/request/428605?by_group=None&cmd=addreview
INFO:check_source.py:POST https://api.opensuse.org/request/428605?cmd=addreview&by_user=factory-repo-checker
INFO:check_source.py:428605 accepted: Check script succeeded
DEBUG:check_source.py:setting 428605 to accepted
```