### PR TITLE
stagingapi: update_status_comments() include link to dashboard.

### DIFF
--- a/osclib/stagingapi.py
+++ b/osclib/stagingapi.py
@@ -1199,7 +1199,8 @@ class StagingAPI(object):
 
         meta = self.get_prj_pseudometa(project)
         lines = ['<!--- osc staging %s --->' % command]
-        lines.append('The list of requests tracked in %s has changed:\n' % project)
+        dashboard_url = '{}/project/staging_projects/{}/{}'.format(self.apiurl, self.project, self.extract_staging_short(project))
+        lines.append('The list of requests tracked in [%s](%s) has changed:\n' % (project, dashboard_url))
         for req in meta['requests']:
             author = req.get('autor', None)
             if not author:


### PR DESCRIPTION
Requested in #573.

Fully tested by running:
```python
api.update_status_comments('openSUSE:Leap:42.3:Staging:adi:9', 'select')
```

Which resulted in the correct link in [comment](https://build.opensuse.org/project/show/openSUSE:Leap:42.3:Staging:adi:9).

I debated if the link should be placed around a new piece of text like `(dashboard)` or somesuch, but given the comment is on the project page the only other relevant link related to just the project seems like dashboard. Either way easy to change since url is correct.

The new `extract_staging_short()` from `request_splitter` did the trick and works for both letter and adi. :)