### PR TITLE
ReviewBot & leaper: provide deduplicate method for leaper comment (and other fixes)

### DIFF
--- a/ReviewBot.py
+++ b/ReviewBot.py
@@ -30,7 +30,6 @@ from osclib.comments import CommentAPI
 from osclib.memoize import memoize
 import signal
 import datetime
-from collections import namedtuple
 
 try:
     from xml.etree import cElementTree as ET

--- a/ReviewBot.py
+++ b/ReviewBot.py
@@ -25,6 +25,7 @@ import logging
 from optparse import OptionParser
 import cmdln
 from collections import namedtuple
+from collections import OrderedDict
 from osclib.comments import CommentAPI
 from osclib.memoize import memoize
 import signal
@@ -386,6 +387,9 @@ class ReviewBot(object):
 
     def comment_handler_remove(self):
         self.logger.removeHandler(self.comment_handler)
+
+    def comment_handler_lines_deduplicate(self):
+        self.comment_handler.lines = list(OrderedDict.fromkeys(self.comment_handler.lines))
 
     def comment_find(self, request=None, state=None, result=None):
         """Return previous comments by current bot and matching criteria."""

--- a/ReviewBot.py
+++ b/ReviewBot.py
@@ -257,7 +257,7 @@ class ReviewBot(object):
 
     def check_action__default(self, req, a):
         self.logger.error("unhandled request type %s"%a.type)
-        ret = None
+        return None
 
     def check_source_submission(self, src_project, src_package, src_rev, target_project, target_package):
         """ default implemention does nothing """

--- a/leaper.py
+++ b/leaper.py
@@ -387,6 +387,9 @@ class Leaper(ReviewBot.ReviewBot):
             else:
                 state = 'done'
                 result = 'declined'
+            # Since leaper calls other bots (like maintbot) comments may
+            # sometimes contain identical lines (like for unhandled requests).
+            self.comment_handler_lines_deduplicate()
             self.comment_write(state, result)
 
         if self.needs_release_manager:

--- a/leaper.py
+++ b/leaper.py
@@ -430,11 +430,6 @@ class Leaper(ReviewBot.ReviewBot):
         return request_ok
 
     def check_action__default(self, req, a):
-        # decline all other requests for fallback reviewer
-        self.logger.debug("auto decline request type %s"%a.type)
-        return False
-
-    def check_action__default(self, req, a):
         self.logger.info("unhandled request type %s"%a.type)
         self.needs_release_manager = True
         return True

--- a/leaper.py
+++ b/leaper.py
@@ -430,7 +430,7 @@ class Leaper(ReviewBot.ReviewBot):
         return request_ok
 
     def check_action__default(self, req, a):
-        self.logger.info("unhandled request type %s"%a.type)
+        super(Leaper, self).check_action__default(req, a)
         self.needs_release_manager = True
         return True
 


### PR DESCRIPTION
- **ReviewBot & leaper: provide deduplicate method for leaper comment.**
- leaper: utilize ReviewBot check_action__default() message.
- ReviewBot: check_action__default() should return None not set ret.
- leaper: drop extra definition of check_action__default().
- ReviewBot: drop duplicate import namedtuple.

This resolves the duplicate line in comment on unhandled request types (like sr#457061).

Before:
```
unhandled request type delete

unhandled request type delete

request needs review by release management
```

After:
```
unhandled request type delete

request needs review by release management
```

I debated making the maintbot check conditional or similar, but seems like this can occur in a variety of ways and even more in the future. If maintbot ends up supporting different types of requests than leaper the message may be appropriate, etc. As such I implemented deduplicate via `list(OrderedDict.fromkeys(self.comment_handler.lines))`.

Additionally, there are two definitions of `check_action__default()` one after the other in `leaper.py`. The second one was added later and is the current behavior so I dropped the older one.