### PR TITLE
osc-staging: provide --cleanup option for unignore.

### DIFF
--- a/osc-staging.py
+++ b/osc-staging.py
@@ -93,6 +93,7 @@ def _full_project_name(self, project):
               help='print the plugin version')
 @cmdln.option('--no-freeze', dest='no_freeze', action='store_true',
               help='force the select command ignoring the time from the last freeze')
+@cmdln.option('--cleanup', action='store_true', help='cleanup after completing operation')
 @cmdln.option('--no-cleanup', dest='no_cleanup', action='store_true',
               help='do not cleanup remaining packages in staging projects after accept')
 @cmdln.option('--no-bootstrap', dest='bootstrap', action='store_false', default=True,
@@ -136,7 +137,9 @@ def do_staging(self, subcmd, opts, *args):
 
     "ignore" will ignore a request from "list" and "adi" commands until unignored
 
-    "unignore" will remove from ignore list
+    "unignore" will remove from requests from ignore list
+        If the --cleanup flag is included then all ignored requests that were
+        changed from state new or review more than 3 days ago will be removed.
 
     "list" will list/supersede requests for ring packages or all if no rings.
         The package list is used to limit what requests are superseded when
@@ -205,7 +208,7 @@ def do_staging(self, subcmd, opts, *args):
         osc staging freeze [--no-boostrap] PROJECT...
         osc staging frozenage PROJECT...
         osc staging ignore [-m MESSAGE] REQUEST...
-        osc staging unignore REQUEST...|all
+        osc staging unignore [--cleanup] REQUEST...|all
         osc staging list [--supersede] [PACKAGE...]
         osc staging select [--no-freeze] [--move [--from PROJECT] STAGING REQUEST...
         osc staging select [--no-freeze] [[--interactive] [--filter-by...] [--group-by...]] [STAGING...] [REQUEST...]
@@ -229,8 +232,10 @@ def do_staging(self, subcmd, opts, *args):
         min_args, max_args = 1, None
     elif cmd == 'adi':
         min_args, max_args = 0, None
-    elif cmd in ('ignore', 'unignore'):
+    elif cmd == 'ignore':
         min_args, max_args = 1, None
+    elif cmd == 'unignore':
+        min_args, max_args = 0, None
     elif cmd in ('list', 'accept'):
         min_args, max_args = 0, None
     elif cmd in ('cleanup_rings', 'acheck'):
@@ -408,7 +413,7 @@ def do_staging(self, subcmd, opts, *args):
         elif cmd == 'ignore':
             IgnoreCommand(api).perform(args[1:], opts.message)
         elif cmd == 'unignore':
-            UnignoreCommand(api).perform(args[1:])
+            UnignoreCommand(api).perform(args[1:], opts.cleanup)
         elif cmd == 'list':
             ListCommand(api).perform(args[1:], supersede=opts.supersede)
         elif cmd == 'adi':

--- a/osclib/unignore_command.py
+++ b/osclib/unignore_command.py
@@ -1,3 +1,6 @@
+import dateutil.parser
+from datetime import datetime
+
 from osc.core import get_request
 
 
@@ -5,7 +8,7 @@ class UnignoreCommand(object):
     def __init__(self, api):
         self.api = api
 
-    def perform(self, request_ids):
+    def perform(self, request_ids, cleanup=False):
         """
         Unignore a request by removing from ignore list.
         """
@@ -21,6 +24,18 @@ class UnignoreCommand(object):
                 if request_id in requests_ignored:
                     print('Removing {}'.format(request_id))
                     del requests_ignored[request_id]
+
+        if cleanup:
+            now = datetime.now()
+            for request_id in set(requests_ignored):
+                request = get_request(self.api.apiurl, str(request_id))
+                if request.state.name not in ('new', 'review'):
+                    changed = dateutil.parser.parse(request.state.when)
+                    diff = now - changed
+                    if diff.days > 3:
+                        print('Removing {} which was {} {} days ago'
+                              .format(request_id, request.state.name, diff.days))
+                        del requests_ignored[request_id]
 
         diff = length - len(requests_ignored)
         if diff > 0:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 lxml
 PyYAML
 pycurl
+python-dateutil
 urlgrabber
 pyxdg
 cmdln


### PR DESCRIPTION
This would make sense to run under some bot credentials to auto-cleanup. I will go ahead and run again Leap 42.3 for the time being. Since the ignored_requests file is version controlled messages and such can always be recovered if some sort of mistake is made.

Here is the output for Factory:
```
Removing 459341 which was superseded 5 days ago                                                                                            
Removing 451216 which was revoked 33 days ago                                                                                              
Removing 448595 which was superseded 45 days ago
Removing 454181 which was superseded 17 days ago
Removing 454246 which was superseded 15 days ago
Removing 459240 which was superseded 5 days ago
Removing 448102 which was revoked 33 days ago
Removing 445239 which was superseded 29 days ago
Removing 445240 which was superseded 28 days ago
Unignoring 9 requests
```