### PR TITLE
stagingapi: extract_staging_short() correction for non-letter parse.

### DIFF
--- a/osclib/stagingapi.py
+++ b/osclib/stagingapi.py
@@ -315,7 +315,7 @@ class StagingAPI(object):
         return projects
 
     def extract_staging_short(self, p):
-        if not ':' in p:
+        if not p.startswith(self.cstaging):
             return p
         prefix = len(self.cstaging) + 1
         if p.endswith(':DVD'):


### PR DESCRIPTION
Properly, supports the intentions of `adi:1` shorthand.