### PR TITLE
osc-staging: provide rebuild command.

### DIFF
--- a/osc-staging.py
+++ b/osc-staging.py
@@ -44,6 +44,7 @@ from osclib.stagingapi import StagingAPI
 from osclib.cache import Cache
 from osclib.unselect_command import UnselectCommand
 from osclib.repair_command import RepairCommand
+from osclib.rebuild_command import RebuildCommand
 from osclib.request_splitter import RequestSplitter
 
 OSC_STAGING_VERSION = '0.0.1'
@@ -205,6 +206,8 @@ def do_staging(self, subcmd, opts, *args):
 
     "unlock" will remove the staging lock in case it gets stuck
 
+    "rebuild" will rebuild broken packages in the given stagings or all
+
     Usage:
         osc staging accept [--force] [--no-cleanup] [LETTER...]
         osc staging acheck
@@ -223,6 +226,7 @@ def do_staging(self, subcmd, opts, *args):
             [STAGING...] [REQUEST...]
         osc staging unselect REQUEST...
         osc staging unlock
+        osc staging rebuild [STAGING...]
         osc staging repair REQUEST...
     """
     if opts.version:
@@ -252,6 +256,8 @@ def do_staging(self, subcmd, opts, *args):
         min_args, max_args = 0, 0
     elif cmd == 'unlock':
         min_args, max_args = 0, 0
+    elif cmd == 'rebuild':
+        min_args, max_args = 0, None
     else:
         raise oscerr.WrongArgs('Unknown command: %s' % cmd)
     if len(args) - 1 < min_args:
@@ -466,5 +472,7 @@ def do_staging(self, subcmd, opts, *args):
             ListCommand(api).perform(args[1:], supersede=opts.supersede)
         elif cmd == 'adi':
             AdiCommand(api).perform(args[1:], move=opts.move, by_dp=opts.by_develproject, split=opts.split)
+        elif cmd == 'rebuild':
+            RebuildCommand(api).perform(args[1:])
         elif cmd == 'repair':
             RepairCommand(api).perform(args[1:])

--- a/osclib/rebuild_command.py
+++ b/osclib/rebuild_command.py
@@ -1,0 +1,17 @@
+from osc.core import get_request
+from osclib.comments import CommentAPI
+
+
+class RebuildCommand(object):
+    def __init__(self, api):
+        self.api = api
+
+    def perform(self, stagings=None):
+        if not stagings:
+            stagings = self.api.get_staging_projects_short()
+
+        for staging in stagings:
+            status = self.api.project_status(staging)
+            rebuilt = self.api.rebuild_broken(status)
+            for key, code in rebuilt.items():
+                print('rebuild {} {}'.format(key, code))


### PR DESCRIPTION
Often packages will fail to build after becoming stuck or other false negative cases and need to have a rebuild triggered. The process can be tedious if several packages failed in various stagings.

For instance today, there are three Factory stagings that all had stuck packages, but otherwise built fine (E, F, and H). This is another part of the automation flow that I plan to add logic to try and be smart so it can be run automatically, but this is useful as it stands.

I have been keeping a list of stuck and flaky builds that could be used as a basis for the tool. Alternatively, plugging into statistics data should with simple flaky detection pattern should provide fairly decent automation to avoid stuck stagings that just need a package or to rebuilt.

For example the three stuck packages in Factory had the typical:

```
[31113s] qemu-system-x86_64: terminating on signal 15 from pid 21485


Job seems to be stuck here, killed. (after 28800 seconds of inactivity)
```