### PR TITLE
Expand links in diff cmd POST

### DIFF
--- a/check_tags_in_requests.py
+++ b/check_tags_in_requests.py
@@ -84,6 +84,7 @@ by OBS on which this bot relies.
                               'view': 'xml',
                               'opackage': a.tgt_package,
                               'oproject': a.tgt_project,
+                              'expand': '1',
                               'rev': a.src_rev})
         try:
             f = osc.core.http_POST(u)


### PR DESCRIPTION
Set expand:1 to expand links in case the target is a links.
Eg. comparing

iosc api -X POST /source/home:mlin7442:boo1026534/libqt5-qtdeclarative?cmd=diff&withissues=1&view=xml&oproject=SUSE:SLE-12-SP3:GA&opackage=libqt5-qtdeclarative&expand=1

and

iosc api -X POST /source/home:mlin7442:boo1026534/libqt5-qtdeclarative?cmd=diff&withissues=1&view=xml&oproject=SUSE:SLE-12-SP3:GA&opackage=libqt5-qtdeclarative

the change in .changes does not count actually. libqt5-qtdeclarative in
SUSE:SLE-12-SP3:GA is a link to libqt5-qtdeclarative.3900