### PR TITLE
request_splitter: add group min map to devel strategy.

### DIFF
--- a/osclib/request_splitter.py
+++ b/osclib/request_splitter.py
@@ -366,6 +366,9 @@ class StrategyCustom(StrategyNone):
 
 class StrategyDevel(StrategyNone):
     GROUP_MIN = 7
+    GROUP_MIN_MAP = {
+        'YaST:Head': 2,
+    }
 
     def apply(self, splitter):
         super(StrategyDevel, self).apply(splitter)
@@ -374,7 +377,7 @@ class StrategyDevel(StrategyNone):
     def desirable(self, splitter):
         groups = []
         for group, info in sorted(splitter.grouped.items()):
-            if len(info['requests']) >= self.GROUP_MIN:
+            if len(info['requests']) >= self.GROUP_MIN_MAP.get(group, self.GROUP_MIN):
                 groups.append(group)
         return groups
 


### PR DESCRIPTION
Per discussion with @DimStar77 the devel strategy minimum should be lower for YaST:Head packages. Not sure if 2 is right. Additionally, not sure if you just wanted packages to be force group together or isolated. Currently all the strategies result in only those packages placed in a staging. The concept of "handcuffing" packages together that can still be included in a larger group is something I have toyed with, but is not yet implemented.

Also are there any other devel projects that should have special minimums while we are at it?