### PR TITLE
unselect: cleanup stagings left empty after request removal.

### DIFF
--- a/osclib/accept_command.py
+++ b/osclib/accept_command.py
@@ -69,9 +69,6 @@ class AcceptCommand(object):
                                  message='Accept to %s' % self.api.project)
             self.create_new_links(self.api.project, req['package'], oldspecs)
 
-        # Clear pseudometa since it no longer represents the staging.
-        self.api.clear_prj_pseudometa(project)
-
         # A single comment should be enough to notify everybody, since
         # they are already mentioned in the comments created by
         # select/unselect
@@ -82,12 +79,7 @@ class AcceptCommand(object):
                                                                                pkg_list)
         self.comment.add_comment(project_name=project, comment=cmmt)
 
-        # XXX CAUTION - AFAIK the 'accept' command is expected to clean the messages here.
-        self.comment.delete_from(project_name=project)
-
-        self.api.build_switch_prj(project, 'disable')
-        if self.api.item_exists(project + ':DVD'):
-            self.api.build_switch_prj(project + ':DVD', 'disable')
+        self.api.staging_deactivate(project)
 
         return True
 

--- a/osclib/stagingapi.py
+++ b/osclib/stagingapi.py
@@ -1455,3 +1455,15 @@ class StagingAPI(object):
             if e.code == 404:
                 pass
         return None
+
+    def staging_deactivate(self, project):
+        """Cleanup staging after last request is removed and disable building."""
+        # Clear pseudometa since it no longer represents the staging.
+        self.clear_prj_pseudometa(project)
+
+        # Clear all comments.
+        CommentAPI(self.apiurl).delete_from(project_name=project)
+
+        self.build_switch_prj(project, 'disable')
+        if self.item_exists(project + ':DVD'):
+            self.build_switch_prj(project + ':DVD', 'disable')

--- a/osclib/unselect_command.py
+++ b/osclib/unselect_command.py
@@ -30,4 +30,9 @@ class UnselectCommand(object):
 
         # Notify everybody about the changes
         for prj in affected_projects:
-            self.api.update_status_comments(prj, 'unselect')
+            meta = self.api.get_prj_pseudometa(prj)
+            if len(meta['requests']) == 0:
+                # Cleanup like accept since the staging is now empty.
+                self.api.staging_deactivate(prj)
+            else:
+                self.api.update_status_comments(prj, 'unselect')


### PR DESCRIPTION
- **unselect: cleanup stagings left empty after request removal.**
- accept: refactor staging cleanup into stagingapi.

Resolves #735 in addition to a missing cleanup case. I have noticed this in occurring in both Factory and Leap and this explains why.