### PR TITLE
special strategy: drop python*.

### DIFF
--- a/osclib/request_splitter.py
+++ b/osclib/request_splitter.py
@@ -386,8 +386,6 @@ class StrategySpecial(StrategyNone):
         'gcc7',
         'glibc',
         'kernel-source',
-        'python2',
-        'python3',
         'util-linux',
     ]
 


### PR DESCRIPTION
Per IRC discussion with @DimStar77 it seems these are only isolated when an issue arises. Is there any other packages you can think of that should be labeled special that I can add while I'm at it?