### PR TITLE
osc-staging: break out `list --supersede` into separate command.

### DIFF
--- a/osclib/list_command.py
+++ b/osclib/list_command.py
@@ -14,20 +14,10 @@ class ListCommand:
     def __init__(self, api):
         self.api = api
 
-    def perform(self, packages=None, supersede=False):
+    def perform(self):
         """
         Perform the list command
         """
-
-        if not packages:
-            packages = []
-
-        if supersede:
-            if packages:
-                self.api.dispatch_open_requests(packages)
-            else:
-                # First dispatch all possible requests
-                self.api.dispatch_open_requests()
 
         requests = self.api.get_open_requests()
         requests_ignored = self.api.get_ignored_requests()

--- a/osclib/supersede_command.py
+++ b/osclib/supersede_command.py
@@ -1,0 +1,7 @@
+
+class SupersedeCommand(object):
+    def __init__(self, api):
+        self.api = api
+
+    def perform(self, packages=None):
+        self.api.dispatch_open_requests(packages)


### PR DESCRIPTION
Since it really has little to do with the `list` command. Resolved #738 .