### PR TITLE
leaper: allow self submission.

### DIFF
--- a/leaper.py
+++ b/leaper.py
@@ -124,6 +124,12 @@ class Leaper(ReviewBot.ReviewBot):
 
     def check_source_submission(self, src_project, src_package, src_rev, target_project, target_package):
         super(Leaper, self).check_source_submission(src_project, src_package, src_rev, target_project, target_package)
+
+        if src_project == target_project and src_package == target_package:
+            self.logger.info('self submission detected')
+            self.needs_release_manager = True
+            return True
+
         src_srcinfo = self.get_sourceinfo(src_project, src_package, src_rev)
         package = target_package
 


### PR DESCRIPTION
In the same spirit as #682.
Example that makes sense to allow: https://build.opensuse.org/request/show/479616.

Output after change:
```
DEBUG:leaper.py:adding comment to 479616: <!-- Leaper state=done result=accepted -->

openSUSE:Leap:42.3/postfix@8 -> openSUSE:Leap:42.3/postfix

self submission detected
GET https://api.opensuse.org/request/479616
INFO:leaper.py:can't change state, 479616 does not have the reviewer
INFO:leaper.py:479616 accepted: ok
```