### PR TITLE
Delete requests should be handled by repo checker

### DIFF
--- a/check_source.py
+++ b/check_source.py
@@ -198,7 +198,8 @@ class CheckSource(ReviewBot.ReviewBot):
         # Decline the delete request against linked package.
         links = root.findall('linked')
         if links is None or len(links) == 0:
-            self.review_messages['accepted'] = 'Unhandled request type %s' % action.type
+            if not self.skip_add_reviews and self.repo_checker is not None:
+                self.add_review(self.request, by_user=self.repo_checker, msg='Is this delete request safe?')
             return True
         else:
             linked = links[0]


### PR DESCRIPTION
Repo-checker at least has some code to validate if it's safe to delete
a package and gives us the information what else we would break with it.

https://progress.opensuse.org/issues/17746