### PR TITLE
Cleanup ignore and always provide a comment.

### DIFF
--- a/osclib/ignore_command.py
+++ b/osclib/ignore_command.py
@@ -17,13 +17,14 @@ class IgnoreCommand(object):
         length = len(requests_ignored)
 
         for request_id in RequestFinder.find_sr(requests, self.api):
-            request_id = str(request_id)
-            print('Processing {}'.format(request_id))
-            check = self.check_and_comment(request_id, message)
-            if check is not True:
-                print('- {}'.format(check))
-            elif request_id not in requests_ignored:
-                requests_ignored[int(request_id)] = message
+            if request_id in requests_ignored:
+                print('{}: already ignored'.format(request_id))
+                continue
+
+            print('{}: ignored'.format(request_id))
+            requests_ignored[request_id] = message
+            if message:
+                self.comment.add_comment(request_id=str(request_id), comment=message)
 
         diff = len(requests_ignored) - length
         if diff > 0:
@@ -31,16 +32,5 @@ class IgnoreCommand(object):
             self.api.set_ignored_requests(requests_ignored)
         else:
             print('No new requests to ignore')
-
-        return True
-
-    def check_and_comment(self, request_id, message=None):
-        request = get_request(self.api.apiurl, request_id)
-        if not request:
-            return 'not found'
-        if request.actions[0].tgt_project != self.api.project:
-            return 'not targeting {}'.format(self.api.project)
-        if message:
-            self.comment.add_comment(request_id=request_id, comment=message)
 
         return True

--- a/osclib/ignore_command.py
+++ b/osclib/ignore_command.py
@@ -30,8 +30,8 @@ class IgnoreCommand(object):
 
         diff = len(requests_ignored) - length
         if diff > 0:
-            print('Ignoring {} requests'.format(diff))
             self.api.set_ignored_requests(requests_ignored)
+            print('Ignored {} requests'.format(diff))
         else:
             print('No new requests to ignore')
 

--- a/osclib/ignore_command.py
+++ b/osclib/ignore_command.py
@@ -4,6 +4,8 @@ from osclib.request_finder import RequestFinder
 
 
 class IgnoreCommand(object):
+    MESSAGE = 'Ignored: removed from active backlog.'
+
     def __init__(self, api):
         self.api = api
         self.comment = CommentAPI(self.api.apiurl)
@@ -23,8 +25,8 @@ class IgnoreCommand(object):
 
             print('{}: ignored'.format(request_id))
             requests_ignored[request_id] = message
-            if message:
-                self.comment.add_comment(request_id=str(request_id), comment=message)
+            comment = message if message else self.MESSAGE
+            self.comment.add_comment(request_id=str(request_id), comment=comment)
 
         diff = len(requests_ignored) - length
         if diff > 0:

--- a/osclib/stagingapi.py
+++ b/osclib/stagingapi.py
@@ -496,7 +496,7 @@ class StagingAPI(object):
 
     def get_ignored_requests(self):
         ignore = self.load_file_content('{}:Staging'.format(self.project), 'dashboard', 'ignored_requests')
-        if ignore is None:
+        if ignore is None or not ignore:
             return {}
         return yaml.safe_load(ignore)
 

--- a/osclib/unignore_command.py
+++ b/osclib/unignore_command.py
@@ -26,7 +26,7 @@ class UnignoreCommand(object):
         else:
             for request_id in RequestFinder.find_sr(requests, self.api):
                 if request_id in requests_ignored:
-                    print('Removing {}'.format(request_id))
+                    print('{}: unignored'.format(request_id))
                     del requests_ignored[request_id]
                     self.comment.add_comment(request_id=str(request_id), comment=self.MESSAGE)
 
@@ -44,8 +44,8 @@ class UnignoreCommand(object):
 
         diff = length - len(requests_ignored)
         if diff > 0:
-            print('Unignoring {} requests'.format(diff))
             self.api.set_ignored_requests(requests_ignored)
+            print('Unignored {} requests'.format(diff))
         else:
             print('No requests to unignore')
 

--- a/osclib/unignore_command.py
+++ b/osclib/unignore_command.py
@@ -2,12 +2,16 @@ import dateutil.parser
 from datetime import datetime
 
 from osc.core import get_request
+from osclib.comments import CommentAPI
 from osclib.request_finder import RequestFinder
 
 
 class UnignoreCommand(object):
+    MESSAGE = 'Unignored: returned to active backlog.'
+
     def __init__(self, api):
         self.api = api
+        self.comment = CommentAPI(self.api.apiurl)
 
     def perform(self, requests, cleanup=False):
         """
@@ -24,6 +28,7 @@ class UnignoreCommand(object):
                 if request_id in requests_ignored:
                     print('Removing {}'.format(request_id))
                     del requests_ignored[request_id]
+                    self.comment.add_comment(request_id=str(request_id), comment=self.MESSAGE)
 
         if cleanup:
             now = datetime.now()

--- a/osclib/unignore_command.py
+++ b/osclib/unignore_command.py
@@ -2,13 +2,14 @@ import dateutil.parser
 from datetime import datetime
 
 from osc.core import get_request
+from osclib.request_finder import RequestFinder
 
 
 class UnignoreCommand(object):
     def __init__(self, api):
         self.api = api
 
-    def perform(self, request_ids, cleanup=False):
+    def perform(self, requests, cleanup=False):
         """
         Unignore a request by removing from ignore list.
         """
@@ -16,11 +17,10 @@ class UnignoreCommand(object):
         requests_ignored = self.api.get_ignored_requests()
         length = len(requests_ignored)
 
-        if len(request_ids) == 1 and request_ids[0] == 'all':
+        if len(requests) == 1 and requests[0] == 'all':
             requests_ignored = {}
         else:
-            for request_id in request_ids:
-                request_id = int(request_id)
+            for request_id in RequestFinder.find_sr(requests, self.api):
                 if request_id in requests_ignored:
                     print('Removing {}'.format(request_id))
                     del requests_ignored[request_id]


### PR DESCRIPTION
Some ignore/unignore related cleanup based on observed usage.

- ignore|uningore: use past tense in output.
- **ignore: add default comment message if none provided.**
- ignore: remove validation since that is handled by RequestFinder.
- **unignore: add comment when a request is unignored.**
- **unignore: utilize RequestFinder.**

Without a comment the only indication of when a request was ignored/uningored is in the revision history of ignored_requests file.