### PR TITLE
refactor supersede logic and handle different source projects (additional cleanups)

### DIFF
--- a/osclib/list_command.py
+++ b/osclib/list_command.py
@@ -19,15 +19,8 @@ class ListCommand:
         Perform the list command
         """
 
-        if not packages:
-            packages = []
-
         if supersede:
-            if packages:
-                self.api.dispatch_open_requests(packages)
-            else:
-                # First dispatch all possible requests
-                self.api.dispatch_open_requests()
+            self.api.dispatch_open_requests(packages)
 
         requests = self.api.get_open_requests()
         requests_ignored = self.api.get_ignored_requests()

--- a/osclib/stagingapi.py
+++ b/osclib/stagingapi.py
@@ -463,12 +463,10 @@ class StagingAPI(object):
 
         # Consolidate all data from request
         request_id = int(request.get('id'))
-        action = request.findall('action')
-        if not action:
+        action = request.find('action')
+        if action is None:
             msg = 'Request {} has no action'.format(request_id)
             raise oscerr.WrongArgs(msg)
-        # we care only about first action
-        action = action[0]
 
         # Where are we targeting the package
         target_project = action.find('target').get('project')

--- a/osclib/stagingapi.py
+++ b/osclib/stagingapi.py
@@ -430,6 +430,17 @@ class StagingAPI(object):
             self.do_change_review_state(request_id, 'accepted', message=message,
                                         by_group=self.cstaging_group)
 
+    @memoize(session=True)
+    def source_info(self, project, package, rev=None):
+        query = {'view': 'info'}
+        if rev is not None:
+            query['rev'] = rev
+        url = makeurl(self.apiurl, ('source', project, package), query=query)
+        try:
+            return ET.parse(http_GET(url)).getroot()
+        except (urllib2.HTTPError, urllib2.URLError):
+            return None
+
     def superseded_request(self, request, target_pkgs=None):
         """
         Returns a staging info for a request or None

--- a/osclib/stagingapi.py
+++ b/osclib/stagingapi.py
@@ -562,8 +562,12 @@ class StagingAPI(object):
 
         # get all current pending requests
         requests = self.get_open_requests()
+        requests_ignored = self.get_ignored_requests()
         # check if we can reduce it down by accepting some
         for rq in requests:
+            request_id = int(rq.get('id'))
+            if request_id in requests_ignored:
+                continue
             # if self.crings:
             #     self.accept_non_ring_request(rq)
             self.update_superseded_request(rq, packages)

--- a/osclib/stagingapi.py
+++ b/osclib/stagingapi.py
@@ -493,6 +493,7 @@ class StagingAPI(object):
             return True
         return False
 
+    @memoize(session=True)
     def get_ignored_requests(self):
         ignore = self.load_file_content('{}:Staging'.format(self.project), 'dashboard', 'ignored_requests')
         if ignore is None:
@@ -503,6 +504,7 @@ class StagingAPI(object):
         ignore = yaml.dump(ignore_requests, default_flow_style=False)
         self.save_file_content('{}:Staging'.format(self.project), 'dashboard', 'ignored_requests', ignore)
 
+    @memoize(session=True)
     def get_open_requests(self):
         """
         Get all requests with open review for staging project

--- a/osclib/stagingapi.py
+++ b/osclib/stagingapi.py
@@ -441,6 +441,16 @@ class StagingAPI(object):
         except (urllib2.HTTPError, urllib2.URLError):
             return None
 
+    def source_info_request(self, request):
+        action = request.find('action')
+        if action.get('type') != 'submit':
+            return None
+
+        source = action.find('source')
+        return self.source_info(source.get('project'),
+                                source.get('package'),
+                                source.get('rev'))
+
     def superseded_request(self, request, target_pkgs=None):
         """
         Returns a staging info for a request or None

--- a/osclib/stagingapi.py
+++ b/osclib/stagingapi.py
@@ -430,7 +430,7 @@ class StagingAPI(object):
             self.do_change_review_state(request_id, 'accepted', message=message,
                                         by_group=self.cstaging_group)
 
-    def supseded_request(self, request, target_pkgs=None):
+    def superseded_request(self, request, target_pkgs=None):
         """
         Returns a staging info for a request or None
         :param request - a Request instance
@@ -479,7 +479,7 @@ class StagingAPI(object):
         if not target_pkgs:
             target_pkgs = []
 
-        stage_info = self.supseded_request(request, target_pkgs)
+        stage_info = self.superseded_request(request, target_pkgs)
         request_id = int(request.get('id'))
 
         if stage_info:


### PR DESCRIPTION
Implement Leap suggestion tracked in #739 along with some other supersede issues and cleanup refactoring.


- **stagingapi: refactor supersede logic and handle different source projects.**

  Primarily an issue for Leap in that requests originating from different source projects may be submitted for the same package at once. Instead of always superseding the previous request the request will only be superseded if it originates from the same project.

  If different sources md5s are found the request will be ignored and left for manual review and an identical request will be declined.
- **stagingapi: do not attempt to supersede ignored requests.**
- stagingapi: simplify finding action in superseded_request().
- stagingapi: provide source_info_request() helper.
- stagingapi: provide source_info() from ReviewBot.
- **stagingapi: @memoize to get_ignored_requests() and get_open_requests().**

  Based on usage neither of these are refreshed during a single run, but are called multiple times in function chains.
- stagingapi: correct spelling supseded_request() -> superseded_request().
- list: remove duplicate empty list handling for dispatch_open_requests().

The one remaining area for discussion is whether this new logic should be locked behind a flag or if it should be always applied. It seems to make sense to just always apply as Factory should reject requests that do not come from the correct devel project so there is only one valid source anyway. As such the new logic will never be triggered. I am not overly familiar enough to know if this would have an undesired effect for SLE workflow.

Additionally, short of testing by tweaking input I have not encountered a case that would be handled by this code since writing it. Although there was a case shortly before.