### PR TITLE
Cleanup check command doc and extra argument

### DIFF
--- a/osc-staging.py
+++ b/osc-staging.py
@@ -220,7 +220,7 @@ def do_staging(self, subcmd, opts, *args):
         osc staging accept [--force] [--no-cleanup] [LETTER...]
         osc staging acheck
         osc staging adi [--move] [--by-develproject] [--split] [REQUEST...]
-        osc staging check [--old] REPO
+        osc staging check [--old] STAGING
         osc staging cleanup_rings
         osc staging freeze [--no-boostrap] STAGING...
         osc staging frozenage [STAGING...]

--- a/osclib/check_command.py
+++ b/osclib/check_command.py
@@ -11,7 +11,7 @@ class CheckCommand(object):
         :param project: project to check
         :param verbose: do verbose check or not
         """
-        state = self.api.check_project_status(project, verbose)
+        state = self.api.check_project_status(project)
 
         # If the project is empty just skip it
         if not state:


### PR DESCRIPTION
Tiny cleanup that does not fit with anything else, but noticed while working on other requests.

- check: stagingapi.check_project_status() does not have verbose argument.
- osc-staging: check command replace REPO with STAGING in doc.
