### PR TITLE
setprio: utilize project_status() and refactor to support list of stagings.

### DIFF
--- a/osc-staging.py
+++ b/osc-staging.py
@@ -252,7 +252,7 @@ def do_staging(self, subcmd, opts, *args):
     elif cmd == 'frozenage':
         min_args, max_args = 0, None
     elif cmd == 'setprio':
-        min_args, max_args = 0, 1
+        min_args, max_args = 0, None
     elif cmd == 'check':
         min_args, max_args = 0, 1
     elif cmd == 'select':

--- a/osclib/prio_command.py
+++ b/osclib/prio_command.py
@@ -48,24 +48,21 @@ class PrioCommand(object):
                     print e
 
 
-    def perform(self, project=None):
+    def perform(self, projects=None):
         """
-        Check one staging project verbosibly or all of them at once
-        :param project: project to check, None for all
+        Set priority on specific stagings or all of them at once
+        :param projects: projects on which to set priority, None for all
         """
 
-        query = {'format': 'json'}
-        path = [ 'project', 'staging_projects', self.api.project ]
-        if project:
-            path += project
-        url = self.api.makeurl(path, query=query)
-        info = json.load(self.api.retried_GET(url))
-        if not project:
-            for prj in info:
-                if not prj['selected_requests']:
-                    continue
-                self._setprio(prj)
-        else:
+        aggregate = False
+        if not projects:
+            aggregate = True
+            projects = self.api.get_staging_projects()
+
+        for project in projects:
+            info = self.api.project_status(project, aggregate)
+            if not info['selected_requests']:
+                continue
             self._setprio(info)
 
         return True


### PR DESCRIPTION
Per note by @lnussel to leave refactoring to utilize `project_status()` to me.

The existing setup was inconsistent in that it was copied from check, but documented that it supported multiple specific stagings. Assuming that would be a desired feature anyway it has been reworked to both utilize `project_status()` and multiple stagings as input.