### PR TITLE
unselect: support the --cleanup flag to include all obsolete requests.

### DIFF
--- a/osc-staging.py
+++ b/osc-staging.py
@@ -207,6 +207,8 @@ def do_staging(self, subcmd, opts, *args):
     "unselect" will remove from the project - pushing them back to the backlog
         If a message is included the requests will be ignored first.
 
+        Use the --cleanup flag to include all obsolete requests.
+
     "unlock" will remove the staging lock in case it gets stuck
 
     "rebuild" will rebuild broken packages in the given stagings or all
@@ -234,7 +236,7 @@ def do_staging(self, subcmd, opts, *args):
             [--filter-by...] [--group-by...]
             [--merge] [--try-strategies] [--strategy]
             [STAGING...] [REQUEST...]
-        osc staging unselect [-m MESSAGE] REQUEST...
+        osc staging unselect [--cleanup] [-m MESSAGE] [REQUEST...]
         osc staging unlock
         osc staging rebuild [--force] [STAGING...]
         osc staging repair REQUEST...
@@ -258,7 +260,7 @@ def do_staging(self, subcmd, opts, *args):
     elif cmd == 'select':
         min_args, max_args = 0, None
     elif cmd == 'unselect':
-        min_args, max_args = 1, None
+        min_args, max_args = 0, None
     elif cmd == 'adi':
         min_args, max_args = 0, None
     elif cmd == 'ignore':
@@ -350,7 +352,7 @@ def do_staging(self, subcmd, opts, *args):
             if opts.message:
                 print('Ignoring requests first')
                 IgnoreCommand(api).perform(args[1:], opts.message)
-            UnselectCommand(api).perform(args[1:])
+            UnselectCommand(api).perform(args[1:], opts.cleanup)
         elif cmd == 'select':
             # Include list of all stagings in short-hand and by full name.
             existing_stagings = api.get_staging_projects_short(None)

--- a/osclib/unselect_command.py
+++ b/osclib/unselect_command.py
@@ -7,11 +7,20 @@ class UnselectCommand(object):
     def __init__(self, api):
         self.api = api
 
-    def perform(self, packages):
+    def perform(self, packages, cleanup=False):
         """
         Remove request from staging project
         :param packages: packages/requests to delete from staging projects
         """
+
+        if cleanup:
+            count_before = len(packages)
+            for status in self.api.project_status():
+                for request in status['obsolete_requests']:
+                    packages += (str(request['number']),)
+            added = len(packages) - count_before
+            if added > 0:
+                print('Cleanup {} obsolete requests'.format(added))
 
         ignored_requests = self.api.get_ignored_requests()
         affected_projects = set()


### PR DESCRIPTION
Only thing obsolete requests do is hold up stagings. If reopened they can be re-staged. Given that operation requires human intervention the response time is inconsistent and any more complex conditions do not seem useful.