### PR TITLE
support --cleanup for obsolete and untracked requests in unselect and repair commands

### DIFF
--- a/osc-staging.py
+++ b/osc-staging.py
@@ -207,6 +207,8 @@ def do_staging(self, subcmd, opts, *args):
     "unselect" will remove from the project - pushing them back to the backlog
         If a message is included the requests will be ignored first.
 
+        Use the --cleanup flag to include all obsolete requests.
+
     "unlock" will remove the staging lock in case it gets stuck
 
     "rebuild" will rebuild broken packages in the given stagings or all
@@ -234,7 +236,7 @@ def do_staging(self, subcmd, opts, *args):
             [--filter-by...] [--group-by...]
             [--merge] [--try-strategies] [--strategy]
             [STAGING...] [REQUEST...]
-        osc staging unselect [-m MESSAGE] REQUEST...
+        osc staging unselect [--cleanup] [-m MESSAGE] [REQUEST...]
         osc staging unlock
         osc staging rebuild [--force] [STAGING...]
         osc staging repair REQUEST...
@@ -258,7 +260,7 @@ def do_staging(self, subcmd, opts, *args):
     elif cmd == 'select':
         min_args, max_args = 0, None
     elif cmd == 'unselect':
-        min_args, max_args = 1, None
+        min_args, max_args = 0, None
     elif cmd == 'adi':
         min_args, max_args = 0, None
     elif cmd == 'ignore':
@@ -350,7 +352,7 @@ def do_staging(self, subcmd, opts, *args):
             if opts.message:
                 print('Ignoring requests first')
                 IgnoreCommand(api).perform(args[1:], opts.message)
-            UnselectCommand(api).perform(args[1:])
+            UnselectCommand(api).perform(args[1:], opts.cleanup)
         elif cmd == 'select':
             # Include list of all stagings in short-hand and by full name.
             existing_stagings = api.get_staging_projects_short(None)

--- a/osc-staging.py
+++ b/osc-staging.py
@@ -155,6 +155,8 @@ def do_staging(self, subcmd, opts, *args):
     "repair" will attempt to repair the state of a request that has been
         corrupted.
 
+        Use the --cleanup flag to include all untracked requests.
+
     "select" will add requests to the project
         Stagings are expected to be either in short-hand or the full project
         name. For example letter or named stagings can be specified simply as
@@ -239,7 +241,7 @@ def do_staging(self, subcmd, opts, *args):
         osc staging unselect [--cleanup] [-m MESSAGE] [REQUEST...]
         osc staging unlock
         osc staging rebuild [--force] [STAGING...]
-        osc staging repair REQUEST...
+        osc staging repair [--cleanup] [REQUEST...]
         osc staging setprio [STAGING...]
     """
     if opts.version:
@@ -249,8 +251,10 @@ def do_staging(self, subcmd, opts, *args):
     if len(args) == 0:
         raise oscerr.WrongArgs('No command given, see "osc help staging"!')
     cmd = args[0]
-    if cmd in ('freeze', 'repair'):
+    if cmd == 'freeze':
         min_args, max_args = 1, None
+    elif cmd == 'repair':
+        min_args, max_args = 0, None
     elif cmd == 'frozenage':
         min_args, max_args = 0, None
     elif cmd == 'setprio':
@@ -496,6 +500,6 @@ def do_staging(self, subcmd, opts, *args):
         elif cmd == 'rebuild':
             RebuildCommand(api).perform(args[1:], opts.force)
         elif cmd == 'repair':
-            RepairCommand(api).perform(args[1:])
+            RepairCommand(api).perform(args[1:], opts.cleanup)
         elif cmd == 'setprio':
             PrioCommand(api).perform(args[1:])

--- a/osclib/repair_command.py
+++ b/osclib/repair_command.py
@@ -57,11 +57,17 @@ class RepairCommand(object):
         change_review_state(self.api.apiurl, reqid, newstate='accepted', message='Re-evaluation needed', by_project=staging_project)
         self.api.add_review(reqid, by_group=self.api.cstaging_group, msg='Requesting new staging review')
 
-    def perform(self, packages):
+    def perform(self, packages, cleanup=False):
         """
         Repair request in staging project or move it out
         :param packages: packages/requests to repair in staging projects
         """
+
+        if cleanup:
+            untracked = self.api.project_status_requests('untracked')
+            if len(untracked) > 0:
+                print('Cleanup {} untracked requests'.format(len(untracked)))
+                packages += tuple(untracked)
 
         for reqid in RequestFinder.find_sr(packages, self.api):
             self.repair(reqid)

--- a/osclib/stagingapi.py
+++ b/osclib/stagingapi.py
@@ -866,6 +866,14 @@ class StagingAPI(object):
             tobuild += int(repo['tobuild'])
         return final, tobuild
 
+    def project_status_requests(self, request_type):
+        key = '{}_requests'.format(request_type)
+        requests = []
+        for status in self.project_status():
+            for request in status[key]:
+                requests.append(str(request['number']))
+        return requests
+
     def days_since_last_freeze(self, project):
         """
         Checks the last update for the frozen links

--- a/osclib/unselect_command.py
+++ b/osclib/unselect_command.py
@@ -7,11 +7,17 @@ class UnselectCommand(object):
     def __init__(self, api):
         self.api = api
 
-    def perform(self, packages):
+    def perform(self, packages, cleanup=False):
         """
         Remove request from staging project
         :param packages: packages/requests to delete from staging projects
         """
+
+        if cleanup:
+            obsolete = self.api.project_status_requests('obsolete')
+            if len(obsolete) > 0:
+                print('Cleanup {} obsolete requests'.format(len(obsolete)))
+                packages += tuple(obsolete)
 
         ignored_requests = self.api.get_ignored_requests()
         affected_projects = set()


### PR DESCRIPTION
Replaced PR #769 with common code in stagingapi.

- repair: support the --cleanup flag to include all untracked requests.
- unselect: support the --cleanup flag to include all obsolete requests.
- stagingapi: project_status_requests() to extract all requests of type.

Resolves #736.