### PR TITLE
source-checker: utilize array system() calls to handle unescaped input.

### DIFF
--- a/source-checker.pl
+++ b/source-checker.pl
@@ -75,7 +75,7 @@ for my $spec (glob("$dir/*.spec")) {
         $ret = 1;
     }
     if (-f "$old/$changes") {
-        if (system("cmp -s $old/$changes $dir/$changes")) {
+        if (system(("cmp", "-s", "$old/$changes", "$dir/$changes"))) {
             $changes_updated = 1;
         }
     }
@@ -189,7 +189,7 @@ if (-d "$old") {
         }
         close(OSPEC);
         close(NSPEC);
-        system("cp $spec $spec.beforeurlstrip");
+        system(("cp", "$spec", "$spec.beforeurlstrip"));
         rename("$spec.new", "$spec") || die "rename failed";
     }
 


### PR DESCRIPTION
Solve boo#1028567.

Tested via:
```perl
#! /usr/bin/perl

my $var = "README.asciidoc; echo evil;";
system("cat $var"); # outputs evil
system(("cat", "$var")); # does not output evil
# cannot read file literal "README.asciidoc; echo evil;"
```