### PR TITLE
package-news: support s390x arch and walking rpm tree

### DIFF
--- a/factory-package-news/factory-package-news.py
+++ b/factory-package-news/factory-package-news.py
@@ -119,7 +119,7 @@ class ChangeLogger(cmdln.Cmdln):
                 if not iso.is_open() or fd is None:
                     raise Exception("Could not open %s as an ISO-9660 image." %  arg)
 
-                for path in ['/suse/x86_64/', '/suse/noarch']:
+                for path in ['/suse/x86_64', '/suse/noarch', '/suse/s390x']:
                     file_stats = iso.readdir(path)
                     if file_stats is None:
                         continue

--- a/factory-package-news/factory-package-news.py
+++ b/factory-package-news/factory-package-news.py
@@ -143,6 +143,8 @@ class ChangeLogger(cmdln.Cmdln):
             elif os.path.isdir(arg):
                 for root, dirs, files in os.walk(arg):
                     for pkg in [ os.path.join(root, file) for file in files]:
+                        if not pkg.endswith('.rpm'):
+                            continue
                         h = self.readRpmHeader( pkg )
                         _getdata(h)
             else:

--- a/factory-package-news/factory-package-news.py
+++ b/factory-package-news/factory-package-news.py
@@ -121,6 +121,9 @@ class ChangeLogger(cmdln.Cmdln):
 
                 for path in ['/suse/x86_64/', '/suse/noarch']:
                     file_stats = iso.readdir(path)
+                    if file_stats is None:
+                        continue
+
                     for stat in file_stats:
                         filename = stat[0]
                         LSN      = stat[1]


### PR DESCRIPTION
Initial work for #703.

I generated a 63MB pickle file from a full Tumbleweed tree and a 26MB using the latest s390x DVD.