### PR TITLE
osc-staging: handle `select --move` cleanup of empty source project.

### DIFF
--- a/osclib/select_command.py
+++ b/osclib/select_command.py
@@ -139,11 +139,8 @@ class SelectCommand(object):
                 return False
 
         # Notify everybody about the changes
-        self.api.update_status_comments(self.target_project, 'select')
+        self.api.update_status_or_deactivate(self.target_project, 'select')
         for fprj in self.affected_projects:
-            self.api.update_status_comments(fprj, 'select')
-
-        # now make sure we enable the prj if the prj contains any ringed package
-        self.api.build_switch_staging_project(self.target_project)
+            self.api.update_status_or_deactivate(fprj, 'select')
 
         return True

--- a/osclib/stagingapi.py
+++ b/osclib/stagingapi.py
@@ -298,9 +298,6 @@ class StagingAPI(object):
         self.rm_from_prj(source_project, request_id=req_id,
                          msg='Moved to {}'.format(destination_project))
 
-        # Build disable the old project if empty
-        self.build_switch_staging_project(source_project)
-
         return True
 
     def get_staging_projects(self):
@@ -1262,22 +1259,12 @@ class StagingAPI(object):
 
         return False
 
-    def build_switch_staging_project(self, target_project):
+    def build_switch_staging_project(self, target_project, target_flag):
         """
-        Verify what packages are in project and switch the build
-        accordingly.
-        :param target_project: project we validate and switch
+        Switch the build flag for a staging project (includes :DVD).
+        :param target_project: staging project
+        :param target_flag: build target flag
         """
-        meta = self.get_prj_pseudometa(target_project)
-        staged_requests = list()
-        for request in meta['requests']:
-            staged_requests.append(request['id'])
-        target_flag = 'disable'
-        # for adi projects we always build
-        if self.is_adi_project(target_project):
-            target_flag = 'enable'
-        elif not self.crings or self.check_ring_packages(target_project, staged_requests):
-            target_flag = 'enable'
         self.build_switch_prj(target_project, target_flag)
 
         if self.item_exists(target_project + ":DVD"):
@@ -1355,6 +1342,15 @@ class StagingAPI(object):
         """
         url = self.makeurl(['source', project, package, filename])
         http_PUT(url + '?comment=scripted+update', data=content)
+
+    def update_status_or_deactivate(self, project, command):
+        meta = self.get_prj_pseudometa(project)
+        if len(meta['requests']) == 0:
+            # Cleanup like accept since the staging is now empty.
+            self.staging_deactivate(project)
+        else:
+            self.build_switch_staging_project(project, 'enable')
+            self.update_status_comments(project, command)
 
     def update_status_comments(self, project, command):
         """
@@ -1534,6 +1530,4 @@ class StagingAPI(object):
         # Clear all comments.
         CommentAPI(self.apiurl).delete_from(project_name=project)
 
-        self.build_switch_prj(project, 'disable')
-        if self.item_exists(project + ':DVD'):
-            self.build_switch_prj(project + ':DVD', 'disable')
+        self.build_switch_staging_project(project, 'disable')

--- a/osclib/unselect_command.py
+++ b/osclib/unselect_command.py
@@ -36,9 +36,4 @@ class UnselectCommand(object):
 
         # Notify everybody about the changes
         for prj in affected_projects:
-            meta = self.api.get_prj_pseudometa(prj)
-            if len(meta['requests']) == 0:
-                # Cleanup like accept since the staging is now empty.
-                self.api.staging_deactivate(prj)
-            else:
-                self.api.update_status_comments(prj, 'unselect')
+            self.api.update_status_or_deactivate(prj, 'unselect')


### PR DESCRIPTION
- handle build disable in select command just like comment instead of stagingapi move_between_project() for consistency and to reduce double checking the same information via extra API calls
- build_switch_staging_project() provides target_flag parameter rather than trying to figure out flag value since caller has the context to know and again reduces API calls
- build_switch_staging_project() checking conditions are essentially checking if True is True since non-adi projects will always have ring packages or rings disabled entirely. The condition of interest is non-empty. Additionally adi projects are removed if empty so not a terribly useful distinction to make.
- provide helper update_status_or_deactivate() to handle common logic and replace in calling locations

Primarily, `select --move` calls `build_switch_staging_project()` which disables build, but does not do the rest of cleanup like deleting comments so the code should be shared with `accept` and recently `unselect`. Secondly, the caller knows and it is duplicate to have same logic.

```python
if self.is_adi_project(target_project):
elif not self.crings or self.check_ring_packages(target_project, staged_requests):
```
If `not cring` means no adi anyway. If cring and not adi then only allowed to have packages in rings. As such this code simplifies to is empty. Further reduced since callers have already made the appropriate API calls to know if empty and have to do other things if empty anyway.

Resolves #773. I need to test this out on some real examples, but feel free if you need to do a `select --move` or `unselect` resulting in empty staging, or `accept` using this refactored code. The only new logic being on the move. If anything just review reasoning and code and likely a case will arise to test out fully when I am back.