### PR TITLE
adi: create accept comment to be consistent with letter stagings. (and cleanups)

### DIFF
--- a/osclib/accept_command.py
+++ b/osclib/accept_command.py
@@ -68,11 +68,9 @@ class AcceptCommand(object):
                 return False
 
         meta = self.api.get_prj_pseudometa(project)
-        requests = []
         packages = []
         for req in meta['requests']:
             self.api.rm_from_prj(project, request_id=req['id'], msg='ready to accept')
-            requests.append(req['id'])
             packages.append(req['package'])
             msg = 'Accepting staging review for {}'.format(req['package'])
             print(msg)

--- a/osclib/accept_command.py
+++ b/osclib/accept_command.py
@@ -7,13 +7,11 @@ from osc.core import change_request_state
 from osc.core import http_GET, http_PUT, http_DELETE, http_POST
 from osc.core import delete_package
 from datetime import date
-from osclib.comments import CommentAPI
 
 
 class AcceptCommand(object):
     def __init__(self, api):
         self.api = api
-        self.comment = CommentAPI(self.api.apiurl)
 
     def find_new_requests(self, project):
         query = "match=state/@name='new'+and+(action/target/@project='{}'+and+action/@type='submit')".format(project)
@@ -84,16 +82,7 @@ class AcceptCommand(object):
                                  message='Accept to %s' % self.api.project)
             self.create_new_links(self.api.project, req['package'], oldspecs)
 
-        # A single comment should be enough to notify everybody, since
-        # they are already mentioned in the comments created by
-        # select/unselect
-        pkg_list = ", ".join(packages)
-        cmmt = 'Project "{}" accepted.' \
-               ' The following packages have been submitted to {}: {}.'.format(project,
-                                                                               self.api.project,
-                                                                               pkg_list)
-        self.comment.add_comment(project_name=project, comment=cmmt)
-
+        self.api.accept_status_comment(project, packages)
         self.api.staging_deactivate(project)
 
         return True

--- a/osclib/adi_command.py
+++ b/osclib/adi_command.py
@@ -33,9 +33,12 @@ class AdiCommand:
             return
         if self.api.is_user_member_of(self.api.user, 'factory-staging'):
             print query_project, "is ready"
+            packages = []
             for req in info['selected_requests']:
                 print " - %s [%s]"%(req['package'], req['number'])
                 self.api.rm_from_prj(project, request_id=req['number'], msg='ready to accept')
+                packages.append(req['package'])
+            self.api.accept_status_comment(project, packages)
             delete_project(self.api.apiurl, project)
         else:
             print query_project, "ready:", ', '.join(['%s[%s]'%(req['package'], req['number']) for req in info['selected_requests']])

--- a/osclib/stagingapi.py
+++ b/osclib/stagingapi.py
@@ -1397,6 +1397,14 @@ class StagingAPI(object):
         msg = '\n'.join(lines)
         comment_api.add_comment(project_name=project, comment=msg)
 
+    def accept_status_comment(self, project, packages):
+        # A single comment should be enough to notify everybody, since they are
+        # already mentioned in the comments created by select/unselect.
+        comment = 'Project "{}" accepted. ' \
+            'The following packages have been submitted to {}: {}.'.format(
+                project, self.project, ', '.join(packages))
+        CommentAPI(self.apiurl).add_comment(project_name=project, comment=comment)
+
     def mark_additional_packages(self, project, packages):
         """
         Adds packages that the repo checker needs to download from staging prj


### PR DESCRIPTION
- **adi: create accept comment to be consistent with letter stagings.**
- stagingapi: provide accept_status_comment() based on accept command.
- accept: remove unused requests list in perform().

Seems to make sense for the same reasons it does for letter stagings.

I cannot run accept (other than tests) and have not had an adi staging to accept since writing this code.