### PR TITLE
stagingapi: correct supersede call to IgnoreCommand.

### DIFF
--- a/osclib/stagingapi.py
+++ b/osclib/stagingapi.py
@@ -509,7 +509,7 @@ class StagingAPI(object):
                         by_group=self.cstaging_group, message=message)
                 else:
                     # Ingore the new request pending manual review.
-                    IgnoreCommand(self).perform(request_id, message)
+                    IgnoreCommand(self).perform([str(request_id)], message)
 
         return None
 


### PR DESCRIPTION
Fixes #788.

I have been running this locally for the last few days.