### PR TITLE
update_crawler: include superseded requests when looking for existing.

### DIFF
--- a/update_crawler.py
+++ b/update_crawler.py
@@ -149,7 +149,7 @@ class UpdateCrawler(object):
     def _find_existing_request(self, src_project, src_package, rev, dst_project,
                        dst_package):
         """Create a submit request."""
-        states = ['new', 'review', 'declined', 'revoked']
+        states = ['new', 'review', 'declined', 'revoked', 'superseded']
         reqs = osc.core.get_exact_request_list(self.apiurl,
                                                src_project,
                                                dst_project,


### PR DESCRIPTION
Prevents situation that can create a loop of update_crawler requests, superseded and another update_crawler request.

Should fix #791.