### PR TITLE
devel-project: gracefully skip when removal of previous comment fails.

### DIFF
--- a/devel-project.py
+++ b/devel-project.py
@@ -184,7 +184,14 @@ def remind_comment(apiurl, repeat_age, request_id, project, package=None):
             return
 
         # Repeat notification so remove old comment.
-        comment_api.delete(comment['id'])
+        try:
+            comment_api.delete(comment['id'])
+        except HTTPError, e:
+            if e.code == 403:
+                # Gracefully skip when previous reminder was by another user.
+                print('  unable to remove previous reminder')
+                return
+            raise e
 
     userids = sorted(maintainers_get(apiurl, project, package))
     if len(userids):


### PR DESCRIPTION
Given that previous comment is used as a basis for determining the time since last reminder if it cannot be removed a new reminder should not be created.

Provides workaround for #800. This code should be irrelevant after all previous reminder comments are either removed or no longer relevant. This also allows for others to run the reminder script without causing each other to crash.

I'll go ahead and delete my previous comments after seeing a full run using this code.