### PR TITLE
request_splitter: switch from build percentage to staging age for merge.

### DIFF
--- a/osclib/request_splitter.py
+++ b/osclib/request_splitter.py
@@ -10,7 +10,7 @@ class RequestSplitter(object):
         self.in_ring = in_ring
         self.mergeable_build_percent = 80
         # 55 minutes to avoid two staging bot loops of 30 minutes
-        self.age_threshold = 55 * 60
+        self.request_age_threshold = 55 * 60
 
         self.requests_ignored = self.api.get_ignored_requests()
 
@@ -97,7 +97,7 @@ class RequestSplitter(object):
         if history is not None:
             created = dateutil.parser.parse(request.find('history').get('when'))
             delta = datetime.utcnow() - created
-            request.set('aged', str(delta.total_seconds() > self.age_threshold))
+            request.set('aged', str(delta.total_seconds() >= self.request_age_threshold))
 
         target = request.find('./action/target')
         target_project = target.get('project')

--- a/osclib/stagingapi.py
+++ b/osclib/stagingapi.py
@@ -15,6 +15,7 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 from cStringIO import StringIO
+from datetime import datetime
 import json
 import logging
 import urllib2
@@ -691,6 +692,7 @@ class StagingAPI(object):
         data['splitter_info'] = {
             'group': group,
             'strategy': strategy_info,
+            'activated': str(datetime.utcnow()),
         }
         self.set_prj_pseudometa(project, data)
 


### PR DESCRIPTION
- 446a30dde05a3583665a25ce14438376750f20af:
  **request_splitter: switch from build percentage to staging age for merge.**

  Using build percentage is sub-optimal since many events can reset the
  percentage which can result in additional requests being merged into the
  staging. A better metric is the time since the first request was added to
  the staging (the age of the staging). Unfortunately, this is not trivial to
  determine especially given that the original request may be superseded or
  unstaged entirely. As such the datetime at which the staging was activated
  is stored in the staging pseudometa. A max age is then used to allow for
  merging up until that point.

- d8f7d03c339b5106c761edc76f4ff4068271a08e:
  **request_splitter: allow user to override merge conditions.**

- 83f425f23a2da1f9d5b26df9d0c021bd76ddc938:
  request_splitter: s/age_threshold/request_age_threshold/.

  Makes room for more age related variables. My gut was to do this in the
  first place which seems correct now.

Fixes #793.

This `allow user to override merge conditions` commit means that one can do the following on a staging that would otherwise not be considered mergeable.

```
osc staging select --merge A
```

Which will only work if the staging was setup with a request splitter strategy before. This is handy when a staging is failed/acceptable and one wants to rebuild with a bunch of new requests matching the strategy.

The overall change is to automatically merge requests into a staging for up to 8 hours after it was originally activated. Automatically merging requests outside of that for things like fixing failing builds will be handled separately.