### PR TITLE
request_splitter: add super strategy for representing devel groups.

### DIFF
--- a/osc-staging.py
+++ b/osc-staging.py
@@ -431,6 +431,7 @@ def do_staging(self, subcmd, opts, *args):
                         temp.write(yaml.safe_dump(splitter.proposal, default_flow_style=False) + '\n\n')
                         temp.write('# move requests between stagings or comment/remove them\n')
                         temp.write('# change the target staging for a group\n')
+                        temp.write('# remove the group, requests, staging, or strategy to skip\n')
                         temp.write('# stagings\n')
                         if opts.merge:
                             temp.write('# - merged: {}\n'

--- a/osc-staging.py
+++ b/osc-staging.py
@@ -204,7 +204,25 @@ def do_staging(self, subcmd, opts, *args):
 
         select A
 
-        Interactive mode allows the proposal to be modified before application.
+        Built in strategies may be specified as well. For example:
+
+        select --strategy devel
+        select --strategy special
+        select --strategy super
+
+        The default is none and custom is used with any filter-by or group-by
+        arguments are provided.
+
+        To merge applicable requests into an existing staging.
+
+        select --merge A
+
+        To automatically try all available strategies.
+
+        select --try-strategies
+
+        These concepts can be combined and interactive mode allows the proposal
+        to be modified before it is executed.
 
     "unselect" will remove from the project - pushing them back to the backlog
         If a message is included the requests will be ignored first.

--- a/osclib/request_splitter.py
+++ b/osclib/request_splitter.py
@@ -52,8 +52,10 @@ class RequestSplitter(object):
                         'contains("{requests}", concat(" ", ./action/target/@package, " "))'
                         .format(requests=requests))
 
-    def group_by(self, xpath):
+    def group_by(self, xpath, required=False):
         self.groups.append(ET.XPath(xpath))
+        if required:
+            self.filter_add(xpath)
 
     def filter_only(self):
         ret = []
@@ -401,7 +403,7 @@ class StrategyDevel(StrategyNone):
 
     def apply(self, splitter):
         super(StrategyDevel, self).apply(splitter)
-        splitter.group_by('./action/target/@devel_project')
+        splitter.group_by('./action/target/@devel_project', True)
 
     def desirable(self, splitter):
         groups = []

--- a/osclib/request_splitter.py
+++ b/osclib/request_splitter.py
@@ -90,7 +90,7 @@ class RequestSplitter(object):
     def supplement(self, request):
         """ Provide additional information for grouping """
         if request.get('ignored'):
-            # Only supliment once.
+            # Only supplement once.
             return
 
         history = request.find('history')


### PR DESCRIPTION
- cc8a53f5172767e39b00284e52f75f82c20067af:
  osc-staging: select: extend doc to cover [try-]strategy[s] and merge.

- 5e0ed06ae6aead3924e7892e56471dd3112cb9f0:
    osc-staging: select -i: include note about skipping.

- 959a8f7905225107dadef9cc02b82cddfc2c826d:
  **request_splitter: add super strategy for representing devel groups.**

- 59eda5d82db110d3b99aabb450f9b2361490f7b2:
  request_splitter: group_by(): provide required option and use in devel.

  Staging packages with no devel project as a result of devel strategy seems
  like the incorrect behavior.

- 232219363cd87f4175963a72cbae4bee6baa5e8a:
  request_splitter: s/supliment/supplement/ in comment.