### PR TITLE
request_splitter: provide quick strategy based on lack of reviews needed.

### DIFF
--- a/osclib/request_splitter.py
+++ b/osclib/request_splitter.py
@@ -374,6 +374,9 @@ class Strategy(object):
             info['args'] = self.kwargs
         return info
 
+    def desirable(self, splitter):
+        return splitter.grouped.keys()
+
 class StrategyNone(Strategy):
     def apply(self, splitter):
         splitter.filter_add('./action[not(@type="add_role" or @type="change_devel")]')
@@ -466,6 +469,3 @@ class StrategySpecial(StrategyNone):
         super(StrategySpecial, self).apply(splitter)
         splitter.filter_add_requests(self.PACKAGES)
         splitter.group_by('./action/target/@package')
-
-    def desirable(self, splitter):
-        return splitter.grouped.keys()

--- a/osclib/request_splitter.py
+++ b/osclib/request_splitter.py
@@ -306,6 +306,7 @@ class RequestSplitter(object):
     def strategies_try(self):
         strategies = (
             'special',
+            'quick',
             'super',
             'devel',
         )
@@ -453,6 +454,12 @@ class StrategySuper(StrategyDevel):
         super(StrategySuper, self).apply(splitter)
         splitter.groups = []
         splitter.group_by('./action/target/@devel_project_super', True)
+
+class StrategyQuick(StrategyNone):
+    def apply(self, splitter):
+        super(StrategyQuick, self).apply(splitter)
+        splitter.filter_add('./review[@by_user="leaper" and @state="accepted"]')
+        splitter.filter_add('not(./review[not(@by_user="leaper" or @by_group="factory-staging")])')
 
 class StrategySpecial(StrategyNone):
     PACKAGES = [


### PR DESCRIPTION
- cde24ba8b2127789e7d8262f6259a195d337cfb1
  **request_splitter: provide quick strategy based on lack of reviews needed.**

- 380c3f1b77315f6bd81d81db2b688353d44b082c
  request_splitter: provide Strategy.desirable() in base.

  Default should be all groups are desirable which the strategy can override.

Fixes #737.

This looks for requests that have been reviewed by `leaper` and do not require any further review. It may also make sense to allow `leap-reviewers`. The approach seems better than trying to look at source projects and author or some such since all the logic from leaper can be used.

Additionally this could be changed to allow reviews that have already been accepted. This can happen when all stagings are full or during the 55 minute none strategy delay. Either way when the staging-bot is running the request may have all reviews completed. I left this out since those may be more troublesome than a pure update, but seems like it may make sense to allow them.