### PR TITLE
devel-project: ensure self does not end up in list.

### DIFF
--- a/devel-project.py
+++ b/devel-project.py
@@ -66,6 +66,9 @@ def devel_projects_get(apiurl, project):
         if devel is not None:
             devel_projects[devel.attrib['project']] = True
 
+    # Ensure self does not end up in list.
+    del devel_projects[project]
+
     return sorted(devel_projects)
 
 def list(args):


### PR DESCRIPTION
Otherwise, `openSUSE:Factory` ends up in the list and causes undesirable results when using the requires sub-command.

Fixes #802.