### PR TITLE
Wait for Factory reviews

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,7 @@ install:
 check: test
 
 test:
+	# to see more add -v -d -s --nologcapture
 	$(wildcard /usr/bin/nosetests-2.*)
 
 .PHONY: all install test check

--- a/check_tags_in_requests.py
+++ b/check_tags_in_requests.py
@@ -128,8 +128,9 @@ by OBS on which this bot relies.
         return factory_ok
 
     def checkTagNotRequiredOrInRequest(self, req, a):
-        if self.checkTagNotRequired(req, a):
-            return True
+        r = self.checkTagNotRequired(req, a)
+        if r != False:
+            return r
         return self.checkTagInRequest(req, a)
 
     def check_action_submit(self, req, a):

--- a/tests/checktags_tests.py
+++ b/tests/checktags_tests.py
@@ -26,6 +26,7 @@ import httpretty
 import osc
 import urlparse
 import sys
+import re
 from osclib.cache import Cache
 sys.path.append(".")
 
@@ -205,6 +206,11 @@ Pico text editor while also offering a few enhancements.</description>
                                APIURL + "/request/293129?withhistory=1",
                                match_querystring=True,
                                body=self._request_withhistory)
+
+        httpretty.register_uri(httpretty.GET,
+                               re.compile (re.escape(APIURL + "/search/request?")),
+                               match_querystring=True,
+                               body='<collection matches="0"></collection>')
 
         result = {'state_accepted': None}
 


### PR DESCRIPTION
The old code would decline requests instead of waiting for matching
Factory submissions to pass reviews.