### PR TITLE
unselect: filter superseded when using --cleanup.

### DIFF
--- a/osclib/stagingapi.py
+++ b/osclib/stagingapi.py
@@ -921,12 +921,13 @@ class StagingAPI(object):
             tobuild += int(repo['tobuild'])
         return final, tobuild
 
-    def project_status_requests(self, request_type):
+    def project_status_requests(self, request_type, filter_superseded=False):
         key = '{}_requests'.format(request_type)
         requests = []
         for status in self.project_status():
             for request in status[key]:
-                requests.append(str(request['number']))
+                if not filter_superseded or request['superseded_by_id'] is None:
+                    requests.append(str(request['number']))
         return requests
 
     def days_since_last_freeze(self, project):

--- a/osclib/unselect_command.py
+++ b/osclib/unselect_command.py
@@ -14,7 +14,7 @@ class UnselectCommand(object):
         """
 
         if cleanup:
-            obsolete = self.api.project_status_requests('obsolete')
+            obsolete = self.api.project_status_requests('obsolete', filter_superseded=True)
             if len(obsolete) > 0:
                 print('Cleanup {} obsolete requests'.format(len(obsolete)))
                 packages += tuple(obsolete)


### PR DESCRIPTION
Fixes #830.