### PR TITLE
stagingapi: correct project_status_build_percent() formula.

### DIFF
--- a/osclib/stagingapi.py
+++ b/osclib/stagingapi.py
@@ -903,7 +903,7 @@ class StagingAPI(object):
 
     def project_status_build_percent(self, status):
         final, tobuild = self.project_status_build_sum(status)
-        return (final - tobuild) / float(final) * 100
+        return final / float(final + tobuild) * 100
 
     def project_status_build_sum(self, status):
         final, tobuild = self.project_status_build_sum_repos(status['building_repositories'])


### PR DESCRIPTION
final: packages in final state (not final count ie total)
tobuild: packages remaining to build

Fixes #771.