### PR TITLE
supersede: separate command, feedback, and force supersede post source project check

### DIFF
--- a/osc-staging.py
+++ b/osc-staging.py
@@ -263,7 +263,7 @@ def do_staging(self, subcmd, opts, *args):
         osc staging rebuild [--force] [STAGING...]
         osc staging repair [--cleanup] [REQUEST...]
         osc staging setprio [STAGING...]
-        osc staging supersede [PACKAGE...]
+        osc staging supersede [REQUEST...]
     """
     if opts.version:
         self._print_version()

--- a/osc-staging.py
+++ b/osc-staging.py
@@ -47,6 +47,7 @@ from osclib.unselect_command import UnselectCommand
 from osclib.repair_command import RepairCommand
 from osclib.rebuild_command import RebuildCommand
 from osclib.request_splitter import RequestSplitter
+from osclib.supersede_command import SupersedeCommand
 from osclib.prio_command import PrioCommand
 
 OSC_STAGING_VERSION = '0.0.1'
@@ -149,8 +150,6 @@ def do_staging(self, subcmd, opts, *args):
         changed from state new or review more than 3 days ago will be removed.
 
     "list" will list/supersede requests for ring packages or all if no rings.
-        The package list is used to limit what requests are superseded when
-        called with the --supersede option.
 
     "repair" will attempt to repair the state of a request that has been
         corrupted.
@@ -238,6 +237,9 @@ def do_staging(self, subcmd, opts, *args):
         If the force option is included the rebuild checks will be ignored and
         all packages failing to build will be triggered.
 
+    "supersede" will supersede requests were applicable.
+        A request list can be used to limit what is superseded.
+
     Usage:
         osc staging accept [--force] [--no-cleanup] [LETTER...]
         osc staging acheck
@@ -248,7 +250,7 @@ def do_staging(self, subcmd, opts, *args):
         osc staging frozenage [STAGING...]
         osc staging ignore [-m MESSAGE] REQUEST...
         osc staging unignore [--cleanup] [REQUEST...|all]
-        osc staging list [--supersede] [PACKAGE...]
+        osc staging list [--supersede]
         osc staging select [--no-freeze] [--move [--from STAGING]]
             [--add PACKAGE]
             STAGING REQUEST...
@@ -261,6 +263,7 @@ def do_staging(self, subcmd, opts, *args):
         osc staging rebuild [--force] [STAGING...]
         osc staging repair [--cleanup] [REQUEST...]
         osc staging setprio [STAGING...]
+        osc staging supersede [PACKAGE...]
     """
     if opts.version:
         self._print_version()
@@ -296,6 +299,8 @@ def do_staging(self, subcmd, opts, *args):
     elif cmd == 'unlock':
         min_args, max_args = 0, 0
     elif cmd == 'rebuild':
+        min_args, max_args = 0, None
+    elif cmd == 'supersede':
         min_args, max_args = 0, None
     else:
         raise oscerr.WrongArgs('Unknown command: %s' % cmd)
@@ -515,7 +520,7 @@ def do_staging(self, subcmd, opts, *args):
         elif cmd == 'unignore':
             UnignoreCommand(api).perform(args[1:], opts.cleanup)
         elif cmd == 'list':
-            ListCommand(api).perform(args[1:], supersede=opts.supersede)
+            ListCommand(api).perform(supersede=opts.supersede)
         elif cmd == 'adi':
             AdiCommand(api).perform(args[1:], move=opts.move, by_dp=opts.by_develproject, split=opts.split)
         elif cmd == 'rebuild':
@@ -524,3 +529,5 @@ def do_staging(self, subcmd, opts, *args):
             RepairCommand(api).perform(args[1:], opts.cleanup)
         elif cmd == 'setprio':
             PrioCommand(api).perform(args[1:])
+        elif cmd == 'supersede':
+            SupersedeCommand(api).perform(args[1:])

--- a/osclib/list_command.py
+++ b/osclib/list_command.py
@@ -1,5 +1,6 @@
 from osc import oscerr
 from osclib.request_splitter import RequestSplitter
+from osclib.supersede_command import SupersedeCommand
 
 
 class ListCommand:
@@ -14,13 +15,13 @@ class ListCommand:
     def __init__(self, api):
         self.api = api
 
-    def perform(self, packages=None, supersede=False):
+    def perform(self, supersede=False):
         """
         Perform the list command
         """
 
         if supersede:
-            self.api.dispatch_open_requests(packages)
+            SupersedeCommand(self.api).perform()
 
         requests = self.api.get_open_requests()
         requests_ignored = self.api.get_ignored_requests()

--- a/osclib/stagingapi.py
+++ b/osclib/stagingapi.py
@@ -479,8 +479,9 @@ class StagingAPI(object):
             logging.info(msg)
 
         # Only consider if submit or delete and in target_pkgs if provided.
+        is_targeted = target_package in target_pkgs
         if action.get('type') in ['submit', 'delete'] and (
-           not(target_pkgs) or target_package in target_pkgs):
+           not(target_pkgs) or is_targeted):
             stage_info = self.packages_staged.get(target_package)
 
             # Ensure a request for same package is already staged.
@@ -490,7 +491,8 @@ class StagingAPI(object):
 
                 # If both are submits from different source projects then check
                 # the source info and proceed accordingly, otherwise supersede.
-                if not(
+                # A targeted package overrides this condition.
+                if is_targeted or not(
                     request_new.find('action').get('type') == 'submit' and
                     request_old.find('action').get('type') == 'submit' and
                     request_new.find('action/source').get('project') !=

--- a/osclib/stagingapi.py
+++ b/osclib/stagingapi.py
@@ -597,7 +597,7 @@ class StagingAPI(object):
         # check if we can reduce it down by accepting some
         for rq in requests:
             request_id = int(rq.get('id'))
-            if request_id in requests_ignored:
+            if not len(target_requests) and request_id in requests_ignored:
                 continue
             # if self.crings:
             #     self.accept_non_ring_request(rq)

--- a/osclib/stagingapi.py
+++ b/osclib/stagingapi.py
@@ -538,7 +538,7 @@ class StagingAPI(object):
             # Add the new one that should be replacing it
             self.rq_to_prj(request_id, stage_info['prj'])
             self._invalidate_get_open_requests()
-            return True
+            return stage_info
         return False
 
     @memoize(session=True)
@@ -601,7 +601,9 @@ class StagingAPI(object):
                 continue
             # if self.crings:
             #     self.accept_non_ring_request(rq)
-            self.update_superseded_request(rq, target_requests)
+            stage_info = self.update_superseded_request(rq, target_requests)
+            if stage_info:
+                yield (stage_info, rq)
 
     def get_prj_meta(self, project):
         url = make_meta_url('prj', project, self.apiurl)

--- a/osclib/supersede_command.py
+++ b/osclib/supersede_command.py
@@ -3,5 +3,5 @@ class SupersedeCommand(object):
     def __init__(self, api):
         self.api = api
 
-    def perform(self, packages=None):
-        self.api.dispatch_open_requests(packages)
+    def perform(self, requests=None):
+        self.api.dispatch_open_requests(requests)

--- a/osclib/supersede_command.py
+++ b/osclib/supersede_command.py
@@ -4,4 +4,8 @@ class SupersedeCommand(object):
         self.api = api
 
     def perform(self, requests=None):
-        self.api.dispatch_open_requests(requests)
+        for stage_info, request in self.api.dispatch_open_requests(requests):
+            action = request.find('action')
+            target_package = action.find('target').get('package')
+            print('request {} for {} superseded {} in {}'.format(
+                request.get('id'), target_package, stage_info['rq_id'], stage_info['prj']))

--- a/osclib/supersede_command.py
+++ b/osclib/supersede_command.py
@@ -1,0 +1,7 @@
+
+class SupersedeCommand(object):
+    def __init__(self, api):
+        self.api = api
+
+    def perform(self, packages=None):
+        self.api.dispatch_open_requests(packages)


### PR DESCRIPTION
- cf3ce7435eb6c57bbce01bf12d840cb2ecccb4b4
  stagingapi: bypass ignored list when supersede with target_requests.

- 08a31563c44d7a1b268397b8fdccabe5c5a6061c
  supersede: provide feedback about what requests were superseded.

- e213385ca4b174f1189edc92712e2f744ce2a22d
  supersede: allow list of request IDs or packages.

- acc95dbb8499c90d4d9cb987489a0a6d4afb22e9
  stagingapi: enhance supersede target_pkgs to skip source project check.

  This creates a facility for forcing a request, that was ignored due to
  the source check, to supersede the existing one.

- 54f502da375843ce35a9d09ada00505b8fb595bf
  osc-staging: break out `list --supersede PACKAGES...` as separate command.

  Maintains `list --supersede`, but places the explicit supersede based on
  a list of packages in a separate command.

I confirmed that the following work as expected:

- `list --supersede`
- `supersede REQUEST_ID`
- `supersede PACKAGE_NAME`
- `adi` (with requests to supersede)

The `list` and `supersede` commands now have output indicating which requests were superseded while the `adi` output remains the same and still indicates which requests were superseded.

Something of which I was not aware is that the `list --supersede` command supersedes requests staged in `adi` stagings. This remains the same, but will be more obvious since messages are printed. Just clarifying that there was no change in behavior.

New features:

- print feedback about what was done
- can supersede explicitly by REQUEST_ID in addition to PACKAGE_NAME
- can force a request that was ignored due to source project check to supersede

For Leap, when a request is ignored and after manual review needs to supersede the other request one can do the following.

```
osc staging supersede IGNORE_REQUEST_ID|PACKAGE_NAME
```

Followup on same basic idea behind #753.
Fixes #814.