### PR TITLE
stagingapi: convert rebuild_broken to a generator for instant feedback.

### DIFF
--- a/osclib/rebuild_command.py
+++ b/osclib/rebuild_command.py
@@ -13,5 +13,5 @@ class RebuildCommand(object):
         for staging in stagings:
             status = self.api.project_status(staging)
             rebuilt = self.api.rebuild_broken(status, not force)
-            for key, code in rebuilt.items():
+            for key, code in rebuilt:
                 print('rebuild {} {}'.format(key, code))


### PR DESCRIPTION
Otherwise, the rebuild command does not print output until all the rebuilds for a whole staging are completed. With this change each package should be printed immediately.

Plus `project_status_walk()` reduces lines and complexity. It is actually required since python 2.7 does not support `yield from` for recursive calls.