### PR TITLE
ReviewBot: always remove previous comment regardless of the state.

### DIFF
--- a/ReviewBot.py
+++ b/ReviewBot.py
@@ -412,6 +412,9 @@ class ReviewBot(object):
         self.logger.debug('adding comment to {}: {}'.format(request.reqid, message))
 
         if not self.dryrun:
+            if comment is None:
+                # Broaden search to include any comment state.
+                comment, _ = self.comment_api.comment_find(comments, self.bot_name)
             if comment is not None:
                 self.comment_api.delete(comment['id'])
             self.comment_api.add_comment(request_id=request.reqid, comment=str(message))


### PR DESCRIPTION
Fixes #843.

Line 406 include info since that is desired when comparing if too similar:
```python
comment, _ = self.comment_api.comment_find(comments, self.bot_name, info)
```

The new call will broaden search (without `info`) if no comment found (due to state change).