### PR TITLE
cleanup_rings: runtime requiredby check, whitelist, summary, and substantial refactoring

### DIFF
--- a/osclib/cleanup_rings.py
+++ b/osclib/cleanup_rings.py
@@ -13,11 +13,9 @@ class CleanupRings(object):
         self.links = {}
 
     def perform(self):
-        self.check_depinfo_ring('{}:0-Bootstrap'.format(self.api.crings),
-                                '{}:1-MinimalX'.format(self.api.crings))
-        self.check_depinfo_ring('{}:1-MinimalX'.format(self.api.crings),
-                                '{}:2-TestDVD'.format(self.api.crings))
-        self.check_depinfo_ring('{}:2-TestDVD'.format(self.api.crings), None)
+        for index, ring in enumerate(self.api.rings):
+            ring_next = self.api.rings[index + 1] if index + 1 < len(self.api.rings) else None
+            self.check_depinfo_ring(ring, ring_next)
 
     def find_inner_ring_links(self, prj):
         query = {

--- a/osclib/cleanup_rings.py
+++ b/osclib/cleanup_rings.py
@@ -133,7 +133,7 @@ class CleanupRings(object):
         for arch in self.api.ring_archs(prj):
             self.fill_pkgdeps(prj, 'standard', arch)
 
-        if prj == '{}:0-Bootstrap'.format(self.api.crings):
+        if self.api.rings.index(prj) == 0:
             self.check_buildconfig(prj)
         else: # Ring 1 or 2.
             # Always look at DVD archs for image, even in ring 1.

--- a/osclib/cleanup_rings.py
+++ b/osclib/cleanup_rings.py
@@ -12,6 +12,11 @@ class CleanupRings(object):
         self.api = api
         self.links = {}
         self.commands = []
+        self.whitelist = [
+            # Must remain in ring-1 with other kernel packages to keep matching
+            # build number, but is required by virtualbox in ring-2.
+            'kernel-syms',
+        ]
 
     def perform(self):
         for index, ring in enumerate(self.api.rings):
@@ -157,7 +162,9 @@ class CleanupRings(object):
                 self.check_image_bdeps(prj, arch)
 
         for source in self.sources:
-            if source not in self.pkgdeps and source not in self.links:
+            if (source not in self.pkgdeps and
+                source not in self.links and
+                source not in self.whitelist):
                 if source.startswith('texlive-specs-'): # XXX: texlive bullshit packaging
                     continue
                 # Expensive check so left until last.

--- a/osclib/cleanup_rings.py
+++ b/osclib/cleanup_rings.py
@@ -88,8 +88,8 @@ class CleanupRings(object):
                 b = self.bin2src[pkg.text]
                 self.pkgdeps[b] = source
 
-    def check_depinfo_ring(self, prj, nextprj):
-        url = makeurl(self.api.apiurl, ['build', prj, '_result'])
+    def repo_state_acceptable(self, project):
+        url = makeurl(self.api.apiurl, ['build', project, '_result'])
         root = ET.parse(http_GET(url)).getroot()
         for repo in root.findall('result'):
             repostate = repo.get('state', 'missing')
@@ -101,6 +101,11 @@ class CleanupRings(object):
                 if code not in ['succeeded', 'excluded', 'disabled']:
                     print('Package {}/{}/{} is {}'.format(repo.get('project'), repo.get('repository'), package.get('package'), code))
                     return False
+        return True
+
+    def check_depinfo_ring(self, prj, nextprj):
+        if not self.repo_state_acceptable(prj):
+            return False
 
         self.find_inner_ring_links(prj)
         for arch in self.api.cstaging_dvd_archs:

--- a/osclib/cleanup_rings.py
+++ b/osclib/cleanup_rings.py
@@ -117,7 +117,7 @@ class CleanupRings(object):
 
     def check_buildconfig(self, project):
         url = makeurl(self.api.apiurl, ['build', project, 'standard', '_buildconfig'])
-        for line in http_GET(url).read().split('\n'):
+        for line in http_GET(url).read().splitlines():
             if line.startswith('Preinstall:') or line.startswith('Support:'):
                 for prein in line.split(':')[1].split():
                     if prein not in self.bin2src:

--- a/osclib/cleanup_rings.py
+++ b/osclib/cleanup_rings.py
@@ -14,6 +14,7 @@ class CleanupRings(object):
 
     def perform(self):
         for index, ring in enumerate(self.api.rings):
+            print('# {}'.format(ring))
             ring_next = self.api.rings[index + 1] if index + 1 < len(self.api.rings) else None
             self.check_depinfo_ring(ring, ring_next)
 

--- a/osclib/cleanup_rings.py
+++ b/osclib/cleanup_rings.py
@@ -11,12 +11,15 @@ class CleanupRings(object):
         self.sources = set()
         self.api = api
         self.links = {}
+        self.commands = []
 
     def perform(self):
         for index, ring in enumerate(self.api.rings):
             print('# {}'.format(ring))
             ring_next = self.api.rings[index + 1] if index + 1 < len(self.api.rings) else None
             self.check_depinfo_ring(ring, ring_next)
+
+        print('\n'.join(self.commands))
 
     def find_inner_ring_links(self, prj):
         query = {
@@ -144,6 +147,8 @@ class CleanupRings(object):
             if source not in self.pkgdeps and source not in self.links:
                 if source.startswith('texlive-specs-'): # XXX: texlive bullshit packaging
                     continue
-                print('osc rdelete -m cleanup {} {}'.format(prj, source))
+
+                print('# - {}'.format(source))
+                self.commands.append('osc rdelete -m cleanup {} {}'.format(prj, source))
                 if nextprj:
-                    print('osc linkpac {} {} {}').format(self.api.project, source, nextprj)
+                    self.commands.append('osc linkpac {} {} {}'.format(self.api.project, source, nextprj))

--- a/osclib/stagingapi.py
+++ b/osclib/stagingapi.py
@@ -1550,3 +1550,19 @@ class StagingAPI(object):
         if self.rings.index(ring) == 2:
             return self.cstaging_dvd_archs
         return self.cstaging_archs
+
+    def fileinfo_ext_all(self, project, repo, arch, package):
+        url = makeurl(self.apiurl, ['build', project, repo, arch, package])
+        binaries = ET.parse(http_GET(url)).getroot()
+        for binary in binaries.findall('binary'):
+            filename = binary.get('filename')
+            if not filename.endswith('.rpm'):
+                continue
+
+            yield self.fileinfo_ext(project, repo, arch, package, filename)
+
+    def fileinfo_ext(self, project, repo, arch, package, filename):
+        url = makeurl(self.apiurl,
+                      ['build', project, repo, arch, package, filename],
+                      {'view': 'fileinfo_ext'})
+        return ET.parse(http_GET(url)).getroot()

--- a/osclib/stagingapi.py
+++ b/osclib/stagingapi.py
@@ -1545,3 +1545,8 @@ class StagingAPI(object):
         CommentAPI(self.apiurl).delete_from(project_name=project)
 
         self.build_switch_staging_project(project, 'disable')
+
+    def ring_archs(self, ring):
+        if self.rings.index(ring) == 2:
+            return self.cstaging_dvd_archs
+        return self.cstaging_archs


### PR DESCRIPTION
- 41e4d5ae2bd09f35889984367bb5ed7c266bb025:
    **cleanup_rings: provide package whitelist for special cases.**

- aca88d19c08c802f94a537979be6342b7ede171c:
    **cleanup_rings: check runtime requiredby if not a build requirement.**
    
    This check only works if the runtime requirement resides in the same ring.
    The fun case being kernel-syms which is required by virtual box (ring-2),
    but must remain in ring-1 to ensure matching build revision with other
    kernel packages.

- ac031bb915fa026b4886a43b7edb2f5169628774:
    stagingapi: provide fileinfo_ext_all() and fileinfo_ext().

- 4d0e98a00c4ce0a5e73569f3261559f3b7188cac:
    **cleanup_rings: print summary of packages to be dropped and commands last.**

- 39a4914e485035bd058bc02331a45b8cedd89da4:
    cleanup_rings: check ring index instead of string comparison.

- ce8818fd3d51e5843d7be5bf0f912c9ac6c8eb12:
    cleanup_rings: utilize splitlines() in check_buildconfig().

- 51c2f6e0e9d5ea0477ac0a805396972ed63a3367:
    cleanup_rings: extract check_image_bdeps() and check_buildconfig().
    
    - change archs loop to use the archs appropriate for the ring instead of
      always using DVD archs
    - drop check_image_bdeps() out of archs loop since DVD should only look
      at DVD archs even if ring 1

- 50166347e1ef3f0dde6474466fc78e91cd48034c:
    stagingapi: provide ring_archs() to return arch relevant to a ring.

- 1198da8eefc597b135ed7c59c8ec3d568d3197fd:
    cleanup_ring: extract repo_state_acceptable().

- 253b6592b4002f002a1f8cb74c0766aad8c5dd49:
    cleanup_rings: indicate the ring being processed.

- 57174711ab6e302693027f512349baa071e45299:
    cleanup_rings: utilize config ring list rather than hard-coded.

[diff out output change](https://gist.github.com/jberry-suse/b6f6962cacf67bc4b02076b009ecd31e) (note some packages reordered, 6 packages ignored due to runtime checks)

Fixes #759.
The runtime check is likely the basis for #815.

It would appear the second `texlive` check can be dropped with this change, but I'll leave for now. The `kernel-syms` could potentially be handled by only moving linked packages together, but since only applies to kernel it is likely not worth it.

These changes also restrict a package from being dropped form ring-0 through 1 and 2 in a single run. Instead only one ring drop is allowed per run which allows for a rebuild to occur and thus the run-time requirements can be checked. I confirmed that `virtualbox` requirement of `kernel-syms` is not show when quering the information for `kernel-syms` since they are in different projects. Obviously, if all the `requiredby` details were checked (ie all packages queried) this could be handled, but that would be very slow. Also note that it handles self references during runtime `requiredby` checks (like `-devel` packages).

Some ideas on getting around this would be to look at `primary.gz` in product repo as this contains everything in one spot, but I'll leave that for another day. Likely this is enough to make this much more reliable.

I spot checked a few of the packages, but feel free to run this locally or look at previously mentioned gist for the new output. Assuming all looks good lets merge and cleanup the rings for real.