### PR TITLE
MaintenanceChecker: include project in owner query to utilize local devel and improvements.

### DIFF
--- a/check_maintenance_incidents.py
+++ b/check_maintenance_incidents.py
@@ -50,11 +50,7 @@ class MaintenanceChecker(ReviewBot.ReviewBot):
     # XXX: share with checkrepo
     def _maintainers(self, package):
         """Get the maintainer of the package involved in the package."""
-        query = {
-            'binary': package,
-        }
-        url = osc.core.makeurl(self.apiurl, ('search', 'owner'), query=query)
-        root = ET.parse(osc.core.http_GET(url)).getroot()
+        root = osc.core.owner(self.apiurl, package)
         maintainers = [p.get('name') for p in root.findall('.//person') if p.get('role') == 'maintainer']
         if not maintainers:
             for group in [p.get('name') for p in root.findall('.//group') if p.get('role') == 'maintainer']:
@@ -65,11 +61,7 @@ class MaintenanceChecker(ReviewBot.ReviewBot):
 
     def add_devel_project_review(self, req, package):
         """ add devel project/package as reviewer """
-        query = {
-            'binary': package,
-        }
-        url = osc.core.makeurl(self.apiurl, ('search', 'owner'), query=query)
-        root = ET.parse(osc.core.http_GET(url)).getroot()
+        root = osc.core.owner(self.apiurl, package)
 
         package_reviews = set((r.by_project, r.by_package) for r in req.reviews if r.by_project)
         for p in root.findall('./owner'):

--- a/check_maintenance_incidents.py
+++ b/check_maintenance_incidents.py
@@ -47,10 +47,19 @@ class MaintenanceChecker(ReviewBot.ReviewBot):
         ReviewBot.ReviewBot.__init__(self, *args, **kwargs)
         self.review_messages = {}
 
+    @memoize(session=True)
+    def owner_fallback(self, project, package):
+        root = osc.core.owner(self.apiurl, package, project=project)
+        owner = root.find('owner')
+        if not owner or owner.get('project') == project:
+            # Fallback to global (ex Factory) maintainer.
+            root = osc.core.owner(self.apiurl, package)
+        return root
+
     # XXX: share with checkrepo
-    def _maintainers(self, package):
+    def _maintainers(self, project, package):
         """Get the maintainer of the package involved in the package."""
-        root = osc.core.owner(self.apiurl, package)
+        root = self.owner_fallback(project, package)
         maintainers = [p.get('name') for p in root.findall('.//person') if p.get('role') == 'maintainer']
         if not maintainers:
             for group in [p.get('name') for p in root.findall('.//group') if p.get('role') == 'maintainer']:
@@ -61,7 +70,9 @@ class MaintenanceChecker(ReviewBot.ReviewBot):
 
     def add_devel_project_review(self, req, package):
         """ add devel project/package as reviewer """
-        root = osc.core.owner(self.apiurl, package)
+        a = req.actions[0]
+        project = a.tgt_releaseproject if a.type == 'maintenance_incident' else req.actions[0].tgt_project
+        root = self.owner_fallback(project, package)
 
         package_reviews = set((r.by_project, r.by_package) for r in req.reviews if r.by_project)
         for p in root.findall('./owner'):
@@ -122,7 +133,7 @@ class MaintenanceChecker(ReviewBot.ReviewBot):
                     self.logger.info("{} submitted from {}, no maintainer review needed".format(pkgname, a.src_project))
                     return
 
-        maintainers = set(self._maintainers(pkgname))
+        maintainers = set(self._maintainers(project, pkgname))
         if maintainers:
             known_maintainer = False
             for m in maintainers:

--- a/tests/maintenance_tests.py
+++ b/tests/maintenance_tests.py
@@ -147,7 +147,14 @@ class TestMaintenance(unittest.TestCase):
             body = lambda method, uri, headers: change_request(result, method, uri, headers))
 
         httpretty.register_uri(httpretty.GET,
-            rr("/search/owner?binary=mysql-workbench"),
+            APIURL + "/search/owner?project=openSUSE:13.2:Update&binary=mysql-workbench",
+            match_querystring = True,
+            body = """
+                <collection/>
+            """)
+
+        httpretty.register_uri(httpretty.GET,
+            APIURL + "/search/owner?binary=mysql-workbench",
             match_querystring = True,
             body = """
                 <collection>
@@ -259,7 +266,14 @@ class TestMaintenance(unittest.TestCase):
             body = lambda method, uri, headers: change_request(result, method, uri, headers))
 
         httpretty.register_uri(httpretty.GET,
-            rr("/search/owner?binary=mysql-workbench"),
+            APIURL + "/search/owner?project=openSUSE:13.2:Update&binary=mysql-workbench",
+            match_querystring = True,
+            body = """
+                <collection/>
+            """)
+
+        httpretty.register_uri(httpretty.GET,
+            APIURL + "/search/owner?binary=mysql-workbench",
             match_querystring = True,
             body = """
                 <collection>
@@ -335,7 +349,14 @@ class TestMaintenance(unittest.TestCase):
             """)
 
         httpretty.register_uri(httpretty.GET,
-            rr("/search/owner?binary=plan"),
+            APIURL + "/search/owner?project=openSUSE:Backports:SLE-12&binary=plan",
+            match_querystring = True,
+            body = """
+                <collection/>
+            """)
+
+        httpretty.register_uri(httpretty.GET,
+            APIURL + "/search/owner?binary=plan",
             match_querystring = True,
             body = """
                 <collection/>


### PR DESCRIPTION
- 11dc2e167e0c6d8aa48041c8d1072363cd695640:
    MaintenanceChecker: add memoize to owner_fallback().

- 3d768c3f2ed2d67faf21c35b084ff03f137ad8cb:
    MaintenanceChecker: include project in owner query to utilize local devel.
    
    For Leap the devel project may override the Factory one.

- a1cb4aa772882eb3aca2844ebb4febd43339a313:
    MaintenanceChecker: utilize osc.core.owner().

Tested on https://build.opensuse.org/request/show/490193.

Before:
```
DEBUG:leaper.py:author: tiwai, maintainers: michals,jirislaby,michal-m => need review
GET https://api.opensuse.org/search/owner?binary=kernel-source
DEBUG:leaper.py:Kernel:stable/None already is a reviewer, not adding again
```

After:
```
DEBUG:leaper.py:tiwai is maintainer
```

Confirmed previous behavior remained the same in two other cases:

- https://build.opensuse.org/request/show/490555
- https://build.opensuse.org/request/show/490286

Fixes #835.