### PR TITLE
request_splitter: add staging whitelist config option.

### DIFF
--- a/osclib/conf.py
+++ b/osclib/conf.py
@@ -43,6 +43,7 @@ DEFAULT = {
         'openqa': 'https://openqa.opensuse.org',
         'lock': 'openSUSE:%(project)s:Staging',
         'lock-ns': 'openSUSE',
+        'splitter-whitelist': 'B C D E F G',
     },
     r'openSUSE:(?P<project>Leap:[\d.]+)': {
         'staging': 'openSUSE:%(project)s:Staging',

--- a/osclib/request_splitter.py
+++ b/osclib/request_splitter.py
@@ -2,6 +2,7 @@ from datetime import datetime
 import dateutil.parser
 import hashlib
 from lxml import etree as ET
+from osc import conf
 import re
 
 class RequestSplitter(object):
@@ -202,7 +203,11 @@ class RequestSplitter(object):
 
         # Use specified list of stagings, otherwise only empty, letter stagings.
         if len(stagings) == 0:
-            stagings = self.api.get_staging_projects_short()
+            whitelist = conf.config[self.api.project].get('splitter-whitelist')
+            if whitelist:
+                stagings = whitelist.split()
+            else:
+                stagings = self.api.get_staging_projects_short()
             should_always = False
         else:
             # If the an explicit list of stagings was included then always


### PR DESCRIPTION
For the initial Factory usage the bot will be allowed to stage on a subset of the available stagings.

@DimStar77 suggestion in relation to #823.