### PR TITLE
lock: provide command to place a multi-command hold on a project (and lock reason).

### DIFF
--- a/osc-staging.py
+++ b/osc-staging.py
@@ -334,7 +334,7 @@ def do_staging(self, subcmd, opts, *args):
     if opts.wipe_cache:
         Cache.delete_all()
 
-    lock = OBSLock(opts.apiurl, opts.project)
+    lock = OBSLock(opts.apiurl, opts.project, reason=cmd)
     if cmd == 'unlock':
         lock.release()
         return

--- a/osclib/obslock.py
+++ b/osclib/obslock.py
@@ -28,7 +28,7 @@ from osc.core import http_POST
 class OBSLock(object):
     """Implement a distributed lock using a shared OBS resource."""
 
-    def __init__(self, apiurl, project, ttl=3600):
+    def __init__(self, apiurl, project, ttl=3600, reason=None):
         self.apiurl = apiurl
         self.project = project
         self.lock = conf.config[project]['lock']
@@ -36,21 +36,24 @@ class OBSLock(object):
         # TTL is measured in seconds
         self.ttl = ttl
         self.user = conf.config['api_host_options'][apiurl]['user']
+        self.reason = reason
         self.locked = False
 
     def _signature(self):
         """Create a signature with a timestamp."""
-        return '%s@%s' % (self.user, datetime.isoformat(datetime.utcnow()))
+        reason = str(self.reason).replace('@', 'at').replace('#', 'hash')
+        return '%s#%s@%s' % (self.user, reason, datetime.isoformat(datetime.utcnow()))
 
     def _parse(self, signature):
         """Parse a signature into an user and a timestamp."""
-        user, ts = None, None
+        user, reason, ts = None, None, None
         try:
-            user, ts_str = signature.split('@')
+            rest, ts_str = signature.split('@')
+            user, reason = rest.split('#')
             ts = datetime.strptime(ts_str, '%Y-%m-%dT%H:%M:%S.%f')
         except (AttributeError, ValueError):
             pass
-        return user, ts
+        return user, reason, ts
 
     def _read(self):
         url = makeurl(self.apiurl, ['source', self.lock, '_attribute', '%s:LockedBy' % self.ns])
@@ -79,20 +82,20 @@ class OBSLock(object):
             warnings.warn('Locking attribute is not found.  Create one to avoid race conditions.')
             return self
 
-        user, ts = self._parse(self._read())
+        user, reason, ts = self._parse(self._read())
         if user and ts:
             now = datetime.utcnow()
             if now < ts:
                 raise Exception('Lock acquired from the future [%s] by [%s]. Try later.' % (ts, user))
             delta = now - ts
             if delta.seconds < self.ttl:
-                print 'Lock acquired by [%s] %s ago. Try later.' % (user, delta)
+                print 'Lock acquired by [%s] %s ago, reason <%s>. Try later.' % (user, delta, reason)
                 exit(-1)
                 # raise Exception('Lock acquired by [%s]. Try later.' % user)
         self._write(self._signature())
 
         time.sleep(1)
-        user, ts = self._parse(self._read())
+        user, _, _ = self._parse(self._read())
         if user != self.user:
             raise Exception('Race condition, [%s] wins. Try later.' % user)
 
@@ -104,7 +107,7 @@ class OBSLock(object):
         if not self.lock:
             return
 
-        user, ts = self._parse(self._read())
+        user, reason, _ = self._parse(self._read())
         if user == self.user:
             self._write('')
 

--- a/osclib/obslock.py
+++ b/osclib/obslock.py
@@ -108,6 +108,7 @@ class OBSLock(object):
         user, _, _, _ = self._parse(self._read())
         if user != self.user:
             raise Exception('Race condition, [%s] wins. Try later.' % user)
+        self.locked = True
 
         return self
 
@@ -125,6 +126,7 @@ class OBSLock(object):
                 self._write(self._signature())
             elif not reason.startswith('hold') or force:
                 self._write('')
+                self.locked = False
 
     def hold(self, message=None):
         self.reason = 'hold'

--- a/tests/fixtures/source/openSUSE:Factory:Staging/_attribute/openSUSE:LockedBy
+++ b/tests/fixtures/source/openSUSE:Factory:Staging/_attribute/openSUSE:LockedBy
@@ -1,0 +1,5 @@
+<attributes>
+  <attribute name="LockedBy" namespace="openSUSE">
+    <value />
+  </attribute>
+</attributes>

--- a/tests/obs.py
+++ b/tests/obs.py
@@ -262,6 +262,8 @@ class OBS(object):
             },
         }
 
+        self.lock = None
+
         self.meta = {}
 
         self.package = {
@@ -482,6 +484,33 @@ class OBS(object):
     #
     # /source/
     #
+
+    @GET(re.compile(r'/source/openSUSE:Factory:Staging/_attribute/openSUSE:LockedBy'))
+    def source_staging_lock(self, request, uri, headers):
+        """Return staging lock."""
+        response = (404, headers, '<result>Not found</result>')
+        try:
+            lock = self.lock if self.lock else self._fixture(uri)
+            response = (200, headers, lock)
+        except Exception as e:
+            if DEBUG:
+                print uri, e
+
+        if DEBUG:
+            print 'STAGING LOCK', uri, response
+
+        return response
+
+    @POST(re.compile(r'/source/openSUSE:Factory:Staging/_attribute/openSUSE:LockedBy'))
+    def source_staging_lock_put(self, request, uri, headers):
+        """Set the staging lock."""
+        self.lock = request.body
+        response = (200, headers, self.lock)
+
+        if DEBUG:
+            print 'PUT STAGING LOCK', uri, response
+
+        return response
 
     @GET(re.compile(r'/source/openSUSE:Factory:Staging:[A|B|C|J]/_project'))
     def source_staging_project_project(self, request, uri, headers):

--- a/tests/obslock_tests.py
+++ b/tests/obslock_tests.py
@@ -1,0 +1,104 @@
+from datetime import datetime
+import unittest
+from osclib.conf import Config
+from osclib.obslock import OBSLock
+
+from obs import APIURL
+from obs import OBS
+
+
+class TestSelect(unittest.TestCase):
+    def setUp(self):
+        self.obs = OBS()
+        Config('openSUSE:Factory')
+
+    def obs_lock(self, reason='list'):
+        return OBSLock(APIURL, 'openSUSE:Factory', reason=reason)
+
+    def assertLockFail(self, lock):
+        with self.assertRaises(SystemExit):
+            with lock:
+                self.assertFalse(lock.locked)
+
+    def test_lock(self):
+        lock = self.obs_lock()
+        self.assertFalse(lock.locked)
+
+        with lock:
+            self.assertTrue(lock.locked)
+
+            user, reason, reason_sub, ts = lock._parse(lock._read())
+            self.assertIsNotNone(user)
+            self.assertEqual(reason, 'list')
+            self.assertIsNone(reason_sub)
+            self.assertIsInstance(ts, datetime)
+
+        self.assertFalse(lock.locked)
+
+    def test_locked_self(self, hold=False):
+        lock1 = self.obs_lock()
+        lock2 = self.obs_lock()
+
+        self.assertFalse(lock1.locked)
+        self.assertFalse(lock2.locked)
+
+        with lock1:
+            self.assertTrue(lock1.locked)
+            self.assertLockFail(lock2)
+
+        if not hold:
+            # A hold will remain locked.
+            self.assertFalse(lock1.locked)
+        self.assertFalse(lock2.locked)
+
+    def test_hold(self):
+        lock = self.obs_lock('lock')
+        self.assertFalse(lock.locked)
+
+        with lock:
+            self.assertTrue(lock.locked)
+            lock.hold('test')
+
+        self.assertTrue(lock.locked)
+
+        # Same constraints should apply since same user against hold.
+        self.test_locked_self(hold=True)
+
+        # Hold should remain after subcommands are executed.
+        user, reason, reason_sub, ts = lock._parse(lock._read())
+        self.assertIsNotNone(user)
+        self.assertEqual(reason, 'hold: test')
+        self.assertIsNone(reason_sub)
+        self.assertIsInstance(ts, datetime)
+
+        # Other users should not bypass hold.
+        lock_user2 = self.obs_lock()
+        lock_user2.user = 'other'
+        self.assertLockFail(lock_user2)
+
+        lock.release(force=True)
+
+        self.assertFalse(lock.locked)
+
+    def test_expire(self):
+        lock1 = self.obs_lock()
+        lock2 = self.obs_lock()
+        lock2.ttl = 0
+        lock2.user = 'user2'
+
+        self.assertFalse(lock1.locked)
+        self.assertFalse(lock2.locked)
+
+        with lock1:
+            self.assertTrue(lock1.locked)
+            with lock2:
+                self.assertTrue(lock2.locked)
+                user, _, _, _ = lock2._parse(lock2._read())
+                self.assertEqual(user, lock2.user)
+
+    def test_reserved_characters(self):
+        lock = self.obs_lock('some reason @ #night')
+
+        with lock:
+            _, reason, _, _ = lock._parse(lock._read())
+            self.assertEqual(reason, 'some reason at hashnight')


### PR DESCRIPTION
- 630663a1a7557a26461ca8da326011d7bf30e0cf:
    **lock: provide command to place a multi-command hold on a project.**

- 02cd0cf0f8e789e3abd99df0652d9cd34efaaeb9:
    obslock: add reason to indicate what command is being run.

Is backwards compatible so others on older version should still be locked out, but will show the reason as part of username. For example:

```
Lock acquired by [jberry_factory#hold: test] 0:01:55.212672 ago. Try later
```

This provides a reason when seeing a locked out message which will either be the command being run or an indication that a manual hold has been placed on the project.

A normal command lock is still acquired when placing a hold on the project so one will not be able to place a hold if someone else already has a lock. After a hold has been acquired commands may be run like normal and will update the lock to a command level lock. This ensures that one cannot run multiple commands in parallel (just like before) even when a hold is placed on the project.

The documentation update provides a solid example (message being optional):

```
lock -m "checkin round"

list --supersede
adi
accept A B C D E

unlock
```

This new hold can be used to prevent the `staging-bot` (and others) from interrupting.