### PR TITLE
osc-staging: implement remote config and expose more settings to config.

### DIFF
--- a/osc-staging.py
+++ b/osc-staging.py
@@ -338,7 +338,7 @@ def do_staging(self, subcmd, opts, *args):
     opts.project = self._full_project_name(opts.project)
     opts.apiurl = self.get_api_url()
     opts.verbose = False
-    Config(opts.project)
+    config = Config(opts.project)
 
     colorama.init(autoreset=True,
         strip=(opts.no_color or not bool(int(conf.config.get('staging.color', True)))))
@@ -360,6 +360,7 @@ def do_staging(self, subcmd, opts, *args):
 
     with lock:
         api = StagingAPI(opts.apiurl, opts.project)
+        config.apply_remote(api)
 
         # call the respective command and parse args by need
         if cmd == 'check':

--- a/osclib/cache.py
+++ b/osclib/cache.py
@@ -84,6 +84,7 @@ class Cache(object):
         # Project will be marked changed when packages are added/removed.
         '/source/([^/]+)/_meta$': TTL_LONG,
         '/source/([^/]+)/(?:[^/]+)/(?:_meta|_link)$': TTL_LONG,
+        '/source/([^/]+)/dashboard/[^/]+\\?expand=1': TTL_LONG,
         # Handles clearing local cache on package deletes. Lots of queries like
         # updating project info, comment, and package additions.
         '/source/([^/]+)/(?:[^/?]+)(?:\?[^/]+)?$': TTL_LONG,

--- a/osclib/conf.py
+++ b/osclib/conf.py
@@ -44,7 +44,6 @@ DEFAULT = {
         'openqa': 'https://openqa.opensuse.org',
         'lock': 'openSUSE:%(project)s:Staging',
         'lock-ns': 'openSUSE',
-        'splitter-whitelist': 'B C D E F G',
     },
     r'openSUSE:(?P<project>Leap:[\d.]+)': {
         'staging': 'openSUSE:%(project)s:Staging',

--- a/osclib/request_splitter.py
+++ b/osclib/request_splitter.py
@@ -10,9 +10,11 @@ class RequestSplitter(object):
         self.api = api
         self.requests = requests
         self.in_ring = in_ring
+        self.config = conf.config[self.api.project]
+
         # 55 minutes to avoid two staging bot loops of 30 minutes
-        self.request_age_threshold = 55 * 60
-        self.staging_age_max = 8 * 60 * 60
+        self.request_age_threshold = int(self.config.get('splitter-request-age-threshold', 55 * 60))
+        self.staging_age_max = int(self.config.get('splitter-staging-age-max', 8 * 60 * 60))
 
         self.requests_ignored = self.api.get_ignored_requests()
 
@@ -203,7 +205,7 @@ class RequestSplitter(object):
 
         # Use specified list of stagings, otherwise only empty, letter stagings.
         if len(stagings) == 0:
-            whitelist = conf.config[self.api.project].get('splitter-whitelist')
+            whitelist = self.config.get('splitter-whitelist')
             if whitelist:
                 stagings = whitelist.split()
             else:

--- a/tests/config_tests.py
+++ b/tests/config_tests.py
@@ -1,0 +1,28 @@
+import unittest
+from osc import conf
+from osclib.conf import Config
+from osclib.stagingapi import StagingAPI
+
+from obs import APIURL
+from obs import OBS
+
+PROJECT = 'openSUSE:Factory'
+
+
+class TestConfig(unittest.TestCase):
+    def setUp(self):
+        self.obs = OBS()
+        self.config = Config(PROJECT)
+
+    def test_basic(self):
+        self.assertEqual('openSUSE', conf.config[PROJECT]['lock-ns'])
+
+    def test_remote(self):
+        self.assertEqual('local', conf.config[PROJECT]['overridden-by-local'])
+        self.assertIsNone(conf.config[PROJECT].get('remote-only'))
+
+        api = StagingAPI(APIURL, PROJECT)
+        self.config.apply_remote(api)
+
+        self.assertEqual('local', conf.config[PROJECT]['overridden-by-local'])
+        self.assertEqual('remote-indeed', conf.config[PROJECT]['remote-only'])

--- a/tests/fixtures/oscrc
+++ b/tests/fixtures/oscrc
@@ -101,3 +101,6 @@ pass=opensuse
 #       User: mumblegack
 # Force using of keyring for this API
 #keyring = 1
+
+[openSUSE:Factory]
+overridden-by-local = local

--- a/tests/fixtures/source/openSUSE:Factory:Staging/dashboard/config
+++ b/tests/fixtures/source/openSUSE:Factory:Staging/dashboard/config
@@ -1,0 +1,2 @@
+overridden-by-local = remote-nope
+remote-only = remote-indeed


### PR DESCRIPTION
- 4dd6eb8df870a50749aaae6e8403d0ab145c8c77:
    request_splitter: expose age thresholds to config.

- ed9488fb35e68f1d7bb8bc12007e474bed8b6bb1:
    cache: include dashboard files.

- a08c55b6028305f4ff64ff06551480a18670d659:
    osc-staging: implement remote config.

Seems to make sense to use the same format as `.oscrc` the only potential downside is storing more complex data structures in config. Note that the config is loaded in two parts since the most basic config information is required to even know where to look for the remote config. As such the early values loaded in `StagingAPI` may not be overridden remotely, but that makes sense since changing the `cstaging` after loading the config from that staging does not make a lot of sense.

Order of precedence:

- code defaults
- remote config `dashboard/config`
- local `.oscrc`

With the cache tweak no remote calls should be required after first run to load config.

Fixes #813.