### PR TITLE
Drop sys.path plugindir workaround.

### DIFF
--- a/copy-to-132.py
+++ b/copy-to-132.py
@@ -1,7 +1,5 @@
 #!/usr/bin/python
 
-#sys.path.append(os.path.expanduser('~/.osc-plugins'))
-
 import sys
 import os
 import osc

--- a/osc-check_repo.py
+++ b/osc-check_repo.py
@@ -30,9 +30,6 @@ from osc import cmdln
 from osc import conf
 from osc import oscerr
 
-# Expand sys.path to search modules inside the pluging directory
-PLUGINDIR = os.path.dirname(os.path.realpath(__file__.replace('.pyc', '.py')))
-sys.path.append(PLUGINDIR)
 from osclib.conf import Config
 from osclib.checkrepo import CheckRepo
 from osclib.checkrepo import BINCACHE, DOWNLOADS

--- a/osc-staging.py
+++ b/osc-staging.py
@@ -31,10 +31,6 @@ from osc import cmdln
 from osc import conf
 from osc import oscerr
 
-# Expand sys.path to search modules inside the pluging directory
-# FIXME: osc should do that
-PLUGINDIR = os.path.dirname(os.path.realpath(__file__.replace('.pyc', '.py')))
-sys.path.append(PLUGINDIR)
 from osclib.accept_command import AcceptCommand
 from osclib.adi_command import AdiCommand
 from osclib.check_command import CheckCommand

--- a/sync-rebuild.py
+++ b/sync-rebuild.py
@@ -1,7 +1,5 @@
 #!/usr/bin/python
 
-#sys.path.append(os.path.expanduser('~/.osc-plugins'))
-
 import sys
 import os
 import osc

--- a/totest-manager.py
+++ b/totest-manager.py
@@ -26,9 +26,6 @@ import osc
 
 logger = logging.getLogger()
 
-# Expand sys.path to search modules inside the pluging directory
-PLUGINDIR = os.path.expanduser(os.path.dirname(os.path.realpath(__file__)))
-sys.path.append(PLUGINDIR)
 from osclib.conf import Config
 from osclib.stagingapi import StagingAPI
 from osc.core import makeurl


### PR DESCRIPTION
`totest-manager.py` likely never needed it.

Fixes #757.