### PR TITLE
osc-staging: cleanup command and argument number checking (and check multiple projects)

### DIFF
--- a/osc-staging.py
+++ b/osc-staging.py
@@ -262,7 +262,7 @@ def do_staging(self, subcmd, opts, *args):
         osc staging accept [--force] [--no-cleanup] [LETTER...]
         osc staging acheck
         osc staging adi [--move] [--by-develproject] [--split] [REQUEST...]
-        osc staging check [--old] STAGING
+        osc staging check [--old] [STAGING...]
         osc staging cleanup_rings
         osc staging freeze [--no-boostrap] STAGING...
         osc staging frozenage [STAGING...]
@@ -300,7 +300,7 @@ def do_staging(self, subcmd, opts, *args):
     elif cmd == 'setprio':
         min_args, max_args = 0, None
     elif cmd == 'check':
-        min_args, max_args = 0, 1
+        min_args, max_args = 0, None
     elif cmd == 'select':
         min_args, max_args = 0, None
     elif cmd == 'unselect':
@@ -360,8 +360,12 @@ def do_staging(self, subcmd, opts, *args):
 
         # call the respective command and parse args by need
         if cmd == 'check':
-            prj = args[1] if len(args) > 1 else None
-            CheckCommand(api).perform(prj, opts.old)
+            if len(args) == 1:
+                CheckCommand(api).perform(None, opts.old)
+            else:
+                for prj in args[1:]:
+                    CheckCommand(api).perform(prj, opts.old)
+                    print()
         elif cmd == 'freeze':
             for prj in args[1:]:
                 prj = api.prj_from_letter(prj)

--- a/osc-staging.py
+++ b/osc-staging.py
@@ -311,9 +311,9 @@ def do_staging(self, subcmd, opts, *args):
         min_args, max_args = 1, None
     elif cmd == 'unignore':
         min_args, max_args = 0, None
-    elif cmd in ('list', 'accept'):
+    elif cmd  == 'accept':
         min_args, max_args = 0, None
-    elif cmd in ('cleanup_rings', 'acheck'):
+    elif cmd in ('cleanup_rings', 'acheck', 'list'):
         min_args, max_args = 0, 0
     elif cmd == 'lock':
         min_args, max_args = 0, 0

--- a/osc-staging.py
+++ b/osc-staging.py
@@ -291,38 +291,33 @@ def do_staging(self, subcmd, opts, *args):
     if len(args) == 0:
         raise oscerr.WrongArgs('No command given, see "osc help staging"!')
     cmd = args[0]
-    if cmd == 'freeze':
+    if cmd in (
+        'accept',
+        'adi',
+        'check',
+        'frozenage',
+        'unignore',
+        'select',
+        'unselect',
+        'rebuild',
+        'repair',
+        'setprio',
+        'supersede',
+    ):
+        min_args, max_args = 0, None
+    elif cmd in (
+        'freeze',
+        'ignore',
+    ):
         min_args, max_args = 1, None
-    elif cmd == 'repair':
-        min_args, max_args = 0, None
-    elif cmd == 'frozenage':
-        min_args, max_args = 0, None
-    elif cmd == 'setprio':
-        min_args, max_args = 0, None
-    elif cmd == 'check':
-        min_args, max_args = 0, None
-    elif cmd == 'select':
-        min_args, max_args = 0, None
-    elif cmd == 'unselect':
-        min_args, max_args = 0, None
-    elif cmd == 'adi':
-        min_args, max_args = 0, None
-    elif cmd == 'ignore':
-        min_args, max_args = 1, None
-    elif cmd == 'unignore':
-        min_args, max_args = 0, None
-    elif cmd  == 'accept':
-        min_args, max_args = 0, None
-    elif cmd in ('cleanup_rings', 'acheck', 'list'):
+    elif cmd in (
+        'acheck',
+        'cleanup_rings',
+        'list',
+        'lock',
+        'unlock',
+    ):
         min_args, max_args = 0, 0
-    elif cmd == 'lock':
-        min_args, max_args = 0, 0
-    elif cmd == 'unlock':
-        min_args, max_args = 0, 0
-    elif cmd == 'rebuild':
-        min_args, max_args = 0, None
-    elif cmd == 'supersede':
-        min_args, max_args = 0, None
     else:
         raise oscerr.WrongArgs('Unknown command: %s' % cmd)
     if len(args) - 1 < min_args:


### PR DESCRIPTION
- ecc97e05401a0f80e4fd03604eaa5e92ada878ee:
    osc-staging: cleanup command and argument number checking.

- 0d92f3e4a4fafb487ccd7c0d5756409d278c8be6:
    check: support multiple specified projects.

- 7e7cae55578672aead3c2e64bd8a8b5eb60d01ed:
    osc-staging: correct arg count for list.