### PR TITLE
osc-staging: correct --version print.

### DIFF
--- a/osc-staging.py
+++ b/osc-staging.py
@@ -60,7 +60,7 @@ OSC_STAGING_VERSION = '0.0.1'
 
 def _print_version(self):
     """ Print version information about this extension. """
-    print(self.OSC_STAGING_VERSION)
+    print(OSC_STAGING_VERSION)
     quit(0)
 
 


### PR DESCRIPTION
Currently, crashes when `osc staging --version` is run.

```
AttributeError: Osc instance has no attribute 'OSC_STAGING_VERSION'
```

Number is fairly meaningless, but seems silly to crash.