### PR TITLE
factory-package-news-web: do not restrict version to int.

### DIFF
--- a/factory-package-news/factory-package-news-web.py
+++ b/factory-package-news/factory-package-news-web.py
@@ -80,10 +80,9 @@ def current():
             return "", 404
         return os.readlink(fn)
 
-@app.route('/diff/<int:version>')
+@app.route('/diff/<version>')
 def diff(version):
     _dir = get_dir(request.url_root)
-    version = str(version)
     fn = os.path.join(_dir, 'current')
     if not os.path.exists(fn):
         return "current version doesn't exist", 404


### PR DESCRIPTION
Leap version numbers are currently formatted with a leading zero which is stripped when converted to an int.

Another for #703.