### PR TITLE
osc-staging: provide project from directory functionality.

### DIFF
--- a/docs/staging.asciidoc
+++ b/docs/staging.asciidoc
@@ -50,6 +50,33 @@ cd osc-plugin-factory
 ln -sr ./osc-staging.py ./osclib ~/.osc-plugins
 --------------------------------------------------------------------------------
 
+Optionally, one can create directories for each project of interest in order to
+alleviate the need to use the +--project option+ for each command. For example:
+
+--------------------------------------------------------------------------------
+# Or use a directory already initialized by osc.
+mkdir -p "openSUSE:Leap:42.3/.osc"
+cd "openSUSE:Leap:42.3"
+echo openSUSE:Leap:42.3 > .osc/_project
+
+# runs against openSUSE:Leap:42.3
+osc staging list
+
+# runs against openSUSE:Factory
+osc staging -p Factory list
+--------------------------------------------------------------------------------
+
+The following snippet may be useful for addition to a bash PS1.
+
+--------------------------------------------------------------------------------
+if [ -f .osc/_project ] ; then
+  echo " <<$(head -n 1 .osc/_project)>> \$ ";
+fi
+--------------------------------------------------------------------------------
+
+This provides a clear indication of the project against which the commands will
+run and can be merged with an existing complex PS1.
+
 
 Command line
 ------------

--- a/osc-staging.py
+++ b/osc-staging.py
@@ -29,6 +29,7 @@ from colorama import ansi
 
 from osc import cmdln
 from osc import conf
+from osc import core
 from osc import oscerr
 
 from osclib.accept_command import AcceptCommand
@@ -86,7 +87,7 @@ def _full_project_name(self, project):
               help='replace staged requests when superseded')
 @cmdln.option('-f', '--from', dest='from_', metavar='FROMPROJECT',
               help='specify a source project when moving a request')
-@cmdln.option('-p', '--project', dest='project', metavar='PROJECT', default='Factory',
+@cmdln.option('-p', '--project', dest='project', metavar='PROJECT',
               help='indicate the project on which to operate, default is openSUSE:Factory')
 @cmdln.option('--add', dest='add', metavar='PACKAGE',
               help='mark additional packages to be checked by repo checker')
@@ -324,6 +325,13 @@ def do_staging(self, subcmd, opts, *args):
         raise oscerr.WrongArgs('Too few arguments.')
     if max_args is not None and len(args) - 1 > max_args:
         raise oscerr.WrongArgs('Too many arguments.')
+
+    # Allow for determining project from osc store.
+    if not opts.project:
+        if core.is_project_dir('.'):
+            opts.project = core.store_read_project('.')
+        else:
+            opts.project = 'Factory'
 
     # Init the OBS access and configuration
     opts.project = self._full_project_name(opts.project)


### PR DESCRIPTION
I have been rolling this idea around in the back of my head for a while.

Combined with a PS1 it makes it rather clean and clear what project will be used. Simple interface of changing directories to switch targets. For IBS I imagine such users will have the apiurl defaulted to IBS. Obviously, alias works, but kill any autocomplete potential and requires some short-hand abbreviations to be useful.

Just like git operating on current repo, `vagrant up`, etc this seems to fit in.

Combined with a PS1 its a rather nice experience.
```
<jberry> 10:09:11 {project-from-dir} ~/osc-plugin-factory $ cd ../openSUSE:Leap:42.3
<jberry> 10:09:12 <<openSUSE:Leap:42.3>> $ ls
osc-plugin-factory
```

Should not effect those who do not want to use it.