### PR TITLE
conf: explicitly check if config is None (and test).

### DIFF
--- a/osclib/conf.py
+++ b/osclib/conf.py
@@ -155,6 +155,6 @@ class Config(object):
             cp.readfp(io.BytesIO(config))
             self.remote_values = dict(cp.items('remote'))
             self.populate_conf()
-        else:
+        elif config is None:
             # Write empty config to allow for caching.
             api.save_file_content(api.cstaging, 'dashboard', 'config', '')

--- a/tests/config_tests.py
+++ b/tests/config_tests.py
@@ -13,6 +13,7 @@ class TestConfig(unittest.TestCase):
     def setUp(self):
         self.obs = OBS()
         self.config = Config(PROJECT)
+        self.api = StagingAPI(APIURL, PROJECT)
 
     def test_basic(self):
         self.assertEqual('openSUSE', conf.config[PROJECT]['lock-ns'])
@@ -21,8 +22,14 @@ class TestConfig(unittest.TestCase):
         self.assertEqual('local', conf.config[PROJECT]['overridden-by-local'])
         self.assertIsNone(conf.config[PROJECT].get('remote-only'))
 
-        api = StagingAPI(APIURL, PROJECT)
-        self.config.apply_remote(api)
+        self.config.apply_remote(self.api)
 
         self.assertEqual('local', conf.config[PROJECT]['overridden-by-local'])
         self.assertEqual('remote-indeed', conf.config[PROJECT]['remote-only'])
+
+    def test_remote_none(self):
+        self.api.save_file_content(self.api.cstaging, 'dashboard', 'config', '')
+        self.assertEqual(self.obs.dashboard_counts['config'], 1)
+        self.config.apply_remote(self.api)
+        # Ensure blank file not overridden.
+        self.assertEqual(self.obs.dashboard_counts['config'], 1)

--- a/tests/obs.py
+++ b/tests/obs.py
@@ -138,6 +138,9 @@ class OBS(object):
         # Internal status of OBS.  The mockup will use this data to
         # build the responses.  We will try to put responses as XML
         # templates in the fixture directory.
+        self.dashboard = {}
+        self.dashboard_counts = {}
+
         self.requests = {
             '123': {
                 'request': 'new',
@@ -509,6 +512,36 @@ class OBS(object):
 
         if DEBUG:
             print 'PUT STAGING LOCK', uri, response
+
+        return response
+
+    @GET(re.compile(r'/source/openSUSE:Factory:Staging/dashboard/\w+'))
+    def source_staging_dashboard(self, request, uri, headers):
+        """Return staging dashboard file."""
+        filename = re.search(r'/source/[\w:]+/\w+/(\w+)', uri).group(1)
+        response = (404, headers, '<result>Not found</result>')
+        try:
+            contents = self.dashboard.get(filename, self._fixture(uri))
+            response = (200, headers, contents)
+        except Exception as e:
+            if DEBUG:
+                print uri, e
+
+        if DEBUG:
+            print 'STAGING DASHBOARD FILE', uri, response
+
+        return response
+
+    @PUT(re.compile(r'/source/openSUSE:Factory:Staging/dashboard/\w+'))
+    def source_staging_dashboard_put(self, request, uri, headers):
+        """Set the staging dashboard file contents."""
+        filename = re.search(r'/source/[\w:]+/\w+/(\w+)', uri).group(1)
+        self.dashboard[filename] = request.body
+        self.dashboard_counts[filename] = self.dashboard_counts.get(filename, 0) + 1
+        response = (200, headers, request.body)
+
+        if DEBUG:
+            print 'PUT STAGING DASHBOARD FILE', uri, response
 
         return response
 

--- a/tests/obslock_tests.py
+++ b/tests/obslock_tests.py
@@ -7,7 +7,7 @@ from obs import APIURL
 from obs import OBS
 
 
-class TestSelect(unittest.TestCase):
+class TestOBSLock(unittest.TestCase):
     def setUp(self):
         self.obs = OBS()
         Config('openSUSE:Factory')


### PR DESCRIPTION
- cb282eaeace20b60549e78d983a3628b2d121f8d:
    obslock-tests: correct class name.

- cabc9abf402eb10f6002d3ffbb838454070cdba0:
    conf-tess: ensure a blank config is not rewritten (ie loop).

- e755c061aa6d5125c1b5333ea255a34545f47351:
    conf: explicitly check if config is None.
    
    Otherwise a blank file may repeatedly submitted.