### PR TITLE
check_repo: include PLUGINDIR for executing scripts.

### DIFF
--- a/osc-check_repo.py
+++ b/osc-check_repo.py
@@ -30,6 +30,7 @@ from osc import cmdln
 from osc import conf
 from osc import oscerr
 
+PLUGINDIR = os.path.dirname(os.path.realpath(__file__.replace('.pyc', '.py')))
 from osclib.conf import Config
 from osclib.checkrepo import CheckRepo
 from osclib.checkrepo import BINCACHE, DOWNLOADS


### PR DESCRIPTION
Followup to #862 which broke `check_repo` due to usage of `PLUGINDIR` to execute script contained in this repo. Due to the fact that `osc` includes the source of plugins rather than importing and does not leave any trail behind this is really the only way to do this.