### PR TITLE
unselect: add conditions to obsolete filter used by --cleanup (along with refactor and tests).

### DIFF
--- a/osclib/stagingapi.py
+++ b/osclib/stagingapi.py
@@ -922,7 +922,7 @@ class StagingAPI(object):
                 tobuild += int(repo['tobuild'])
         return final, tobuild
 
-    def project_status_requests(self, request_type, filter_superseded=False):
+    def project_status_requests(self, request_type, filter_function=None):
         key = '{}_requests'.format(request_type)
         requests = []
         for status in self.project_status():
@@ -934,8 +934,10 @@ class StagingAPI(object):
                     # requests whose state has changed in the last 5 minutes.
                     continue
 
-                if not filter_superseded or request['superseded_by_id'] is None:
-                    requests.append(str(request['number']))
+                if filter_function and not filter_function(request, updated_delta):
+                    continue
+
+                requests.append(str(request['number']))
 
         return requests
 

--- a/osclib/stagingapi.py
+++ b/osclib/stagingapi.py
@@ -16,6 +16,7 @@
 
 from cStringIO import StringIO
 from datetime import datetime
+import dateutil.parser
 import json
 import logging
 import textwrap
@@ -926,8 +927,16 @@ class StagingAPI(object):
         requests = []
         for status in self.project_status():
             for request in status[key]:
+                updated_at = dateutil.parser.parse(request['updated_at'], ignoretz=True)
+                updated_delta = datetime.utcnow() - updated_at
+                if updated_delta.total_seconds() < 5 * 60:
+                    # Allow for dashboard to update caches by not considering
+                    # requests whose state has changed in the last 5 minutes.
+                    continue
+
                 if not filter_superseded or request['superseded_by_id'] is None:
                     requests.append(str(request['number']))
+
         return requests
 
     def days_since_last_freeze(self, project):

--- a/osclib/unselect_command.py
+++ b/osclib/unselect_command.py
@@ -3,6 +3,9 @@ from osclib.request_finder import RequestFinder
 
 
 class UnselectCommand(object):
+    CLEANUP_WHITELIST = [
+        'leaper',
+    ]
 
     def __init__(self, api):
         self.api = api
@@ -12,7 +15,13 @@ class UnselectCommand(object):
         if request['superseded_by_id'] is not None:
             return False
 
-        return True
+        if (request['state'] == 'revoked' or
+           (request['state'] == 'declined' and (
+                request['creator'] in UnselectCommand.CLEANUP_WHITELIST or
+                updated_delta.days >= 7))):
+            return True
+
+        return False
 
     def perform(self, packages, cleanup=False):
         """

--- a/osclib/unselect_command.py
+++ b/osclib/unselect_command.py
@@ -7,6 +7,13 @@ class UnselectCommand(object):
     def __init__(self, api):
         self.api = api
 
+    @staticmethod
+    def filter_obsolete(request, updated_delta):
+        if request['superseded_by_id'] is not None:
+            return False
+
+        return True
+
     def perform(self, packages, cleanup=False):
         """
         Remove request from staging project
@@ -14,7 +21,7 @@ class UnselectCommand(object):
         """
 
         if cleanup:
-            obsolete = self.api.project_status_requests('obsolete', filter_superseded=True)
+            obsolete = self.api.project_status_requests('obsolete', self.filter_obsolete)
             if len(obsolete) > 0:
                 print('Cleanup {} obsolete requests'.format(len(obsolete)))
                 packages += tuple(obsolete)

--- a/tests/config_tests.py
+++ b/tests/config_tests.py
@@ -4,9 +4,8 @@ from osclib.conf import Config
 from osclib.stagingapi import StagingAPI
 
 from obs import APIURL
+from obs import PROJECT
 from obs import OBS
-
-PROJECT = 'openSUSE:Factory'
 
 
 class TestConfig(unittest.TestCase):

--- a/tests/fixtures/project/staging_projects/openSUSE:Factory.json
+++ b/tests/fixtures/project/staging_projects/openSUSE:Factory.json
@@ -1760,7 +1760,80 @@
         "description": "requests: []\n",
         "missing_reviews": [],
         "name": "openSUSE:Factory:Staging:U",
-        "obsolete_requests": [],
+        "obsolete_requests": [
+            {
+                "accept_at": null,
+                "superseded_by_id": null,
+                "description": "",
+                "creator": "alois",
+                "created_at": "2017-05-02T10:24:19.000Z",
+                "package": "kernel-source",
+                "updated_at": "${update_at_too_recent}",
+                "number": 492436,
+                "state": "revoked",
+                "id": 697437
+            },
+            {
+                "accept_at": null,
+                "superseded_by_id": 492518,
+                "description": "",
+                "creator": "alois",
+                "created_at": "2017-05-02T10:24:19.000Z",
+                "package": "Photini",
+                "updated_at": "2017-05-02T17:14:31.000Z",
+                "number": 492437,
+                "state": "superseded",
+                "id": 697437
+            },
+            {
+                "accept_at": null,
+                "superseded_by_id": null,
+                "description": "",
+                "creator": "alois",
+                "created_at": "2017-05-02T10:24:19.000Z",
+                "package": "kernel-source",
+                "updated_at": "2017-05-02T17:14:31.000Z",
+                "number": 492438,
+                "state": "revoked",
+                "id": 697437
+            },
+            {
+                "accept_at": null,
+                "superseded_by_id": null,
+                "description": "",
+                "creator": "leaper",
+                "created_at": "2017-05-02T10:24:19.000Z",
+                "package": "zypper",
+                "updated_at": "2017-05-02T17:14:31.000Z",
+                "number": 492439,
+                "state": "declined",
+                "id": 697437
+            },
+            {
+                "accept_at": null,
+                "superseded_by_id": null,
+                "description": "",
+                "creator": "alois",
+                "created_at": "2017-05-02T10:24:19.000Z",
+                "package": "phpmyadmin",
+                "updated_at": "${declined_updated_at_under}",
+                "number": 492440,
+                "state": "declined",
+                "id": 697437
+            },
+            {
+                "accept_at": null,
+                "superseded_by_id": null,
+                "description": "",
+                "creator": "alois",
+                "created_at": "2017-05-02T10:24:19.000Z",
+                "package": "adminer",
+                "updated_at": "${declined_updated_at_over}",
+                "number": 492441,
+                "state": "declined",
+                "id": 697437
+            }
+        ],
         "openqa_jobs": [
             {
                 "clone_id": null,

--- a/tests/obs.py
+++ b/tests/obs.py
@@ -14,6 +14,7 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+from datetime import datetime, timedelta
 import os
 import re
 import string
@@ -906,8 +907,12 @@ class OBS(object):
         response = (404, headers, '<result>Not found</result>')
         try:
             path = urlparse.urlparse(uri).path + '.json'
-            fixture = self._fixture(path=path)
-            response = (200, headers, fixture)
+            template = string.Template(self._fixture(path=path))
+            response = (200, headers, template.substitute({
+                'update_at_too_recent': (datetime.utcnow() - timedelta(minutes=2)).isoformat(),
+                'declined_updated_at_under': (datetime.utcnow() - timedelta(days=1)).isoformat(),
+                'declined_updated_at_over': (datetime.utcnow() - timedelta(days=10)).isoformat(),
+            }))
         except Exception as e:
             if DEBUG:
                 print uri, e

--- a/tests/obs.py
+++ b/tests/obs.py
@@ -28,6 +28,7 @@ from osclib.cache import Cache
 
 
 APIURL = 'http://localhost'
+PROJECT = 'openSUSE:Factory'
 
 FIXTURES = os.path.join(os.getcwd(), 'tests/fixtures')
 

--- a/tests/obslock_tests.py
+++ b/tests/obslock_tests.py
@@ -4,16 +4,17 @@ from osclib.conf import Config
 from osclib.obslock import OBSLock
 
 from obs import APIURL
+from obs import PROJECT
 from obs import OBS
 
 
 class TestOBSLock(unittest.TestCase):
     def setUp(self):
         self.obs = OBS()
-        Config('openSUSE:Factory')
+        Config(PROJECT)
 
     def obs_lock(self, reason='list'):
-        return OBSLock(APIURL, 'openSUSE:Factory', reason=reason)
+        return OBSLock(APIURL, PROJECT, reason=reason)
 
     def assertLockFail(self, lock):
         with self.assertRaises(SystemExit):

--- a/tests/unselect_tests.py
+++ b/tests/unselect_tests.py
@@ -15,6 +15,7 @@ class TestUnselect(unittest.TestCase):
         self.api = StagingAPI(APIURL, PROJECT)
 
     def test_cleanup_filter(self):
+        UnselectCommand.config_init(self.api)
         obsolete = self.api.project_status_requests('obsolete', UnselectCommand.filter_obsolete)
         self.assertTrue('492438' in obsolete, 'revoked')
         self.assertTrue('492439' in obsolete, 'declined by leaper')

--- a/tests/unselect_tests.py
+++ b/tests/unselect_tests.py
@@ -1,0 +1,22 @@
+import unittest
+from osclib.conf import Config
+from osclib.stagingapi import StagingAPI
+from osclib.unselect_command import UnselectCommand
+
+from obs import APIURL
+from obs import PROJECT
+from obs import OBS
+
+
+class TestUnselect(unittest.TestCase):
+    def setUp(self):
+        self.obs = OBS()
+        Config(PROJECT)
+        self.api = StagingAPI(APIURL, PROJECT)
+
+    def test_cleanup_filter(self):
+        obsolete = self.api.project_status_requests('obsolete', UnselectCommand.filter_obsolete)
+        self.assertTrue('492438' in obsolete, 'revoked')
+        self.assertTrue('492439' in obsolete, 'declined by leaper')
+        self.assertTrue('492441' in obsolete, 'declined but over threshold')
+        self.assertEqual(len(obsolete), 3)


### PR DESCRIPTION
- ad9ffc486ee554c24d336c87781e5027be61cb27:
    tests/unselect_tests: add test for cleanup fitler.

- 4e26f2cb27a5b448230e3609252c69b8a979cecd:
    tests/obs: define PROJECT as openSUSE:Factory.

- fb47742431d50d5e03ab74650986e5b6ab6b725d:
    **unselect: add conditions to obsolete filter used by --cleanup.**

- 35fce8136699ae25b1443b86826b0fa020b00a4a:
    stagingapi: project_status_requests(): provide filter function.

- 007ed1a21b98d2344fba9b21b1c8001f636a470b:
    **stagingapi: project_status_requests(): filter requests changed < 5 min ago.**

Tests handle the cases of interest along with the general `< 5 min` case which also applies to `untracked`.

Fixes #871.