### PR TITLE
obslock: cleanup hold logic and resolve inheriting an expired hold.

### DIFF
--- a/osclib/obslock.py
+++ b/osclib/obslock.py
@@ -95,13 +95,21 @@ class OBSLock(object):
             if now < ts:
                 raise Exception('Lock acquired from the future [%s] by [%s]. Try later.' % (ts, user))
             delta = now - ts
-            if delta.seconds < self.ttl and not(
-                user == self.user and (reason == 'lock' or reason.startswith('hold'))):
-                print 'Lock acquired by [%s] %s ago, reason <%s>. Try later.' % (user, delta, reason)
-                exit(-1)
-                # raise Exception('Lock acquired by [%s]. Try later.' % user)
-        if reason and reason != 'lock':
-            self.reason_sub = reason
+            if delta.seconds < self.ttl:
+                # Existing lock that has not expired.
+                stop = True
+                if user == self.user:
+                    if reason.startswith('hold'):
+                        # Command being issued during a hold.
+                        self.reason_sub = reason
+                        stop = False
+                    elif reason == 'lock':
+                        # Second pass to acquire hold.
+                        stop = False
+
+                if stop:
+                    print 'Lock acquired by [%s] %s ago, reason <%s>. Try later.' % (user, delta, reason)
+                    exit(-1)
         self._write(self._signature())
 
         time.sleep(1)

--- a/osclib/obslock.py
+++ b/osclib/obslock.py
@@ -95,7 +95,7 @@ class OBSLock(object):
             if now < ts:
                 raise Exception('Lock acquired from the future [%s] by [%s]. Try later.' % (ts, user))
             delta = now - ts
-            if delta.seconds < self.ttl:
+            if delta.total_seconds() < self.ttl:
                 # Existing lock that has not expired.
                 stop = True
                 if user == self.user:

--- a/tests/obslock_tests.py
+++ b/tests/obslock_tests.py
@@ -96,6 +96,25 @@ class TestOBSLock(unittest.TestCase):
                 user, _, _, _ = lock2._parse(lock2._read())
                 self.assertEqual(user, lock2.user)
 
+    def test_expire_hold(self):
+        lock1 = self.obs_lock('lock')
+        lock2 = self.obs_lock('override')
+        lock2.ttl = 0
+        lock2.user = 'user2'
+
+        self.assertFalse(lock1.locked)
+        self.assertFalse(lock2.locked)
+
+        with lock1:
+            self.assertTrue(lock1.locked)
+            lock1.hold('test')
+            with lock2:
+                self.assertTrue(lock2.locked)
+                user, reason, reason_sub, _ = lock2._parse(lock2._read())
+                self.assertEqual(user, lock2.user)
+                self.assertEqual(reason, 'override')
+                self.assertEqual(reason_sub, None, 'does not inherit hold')
+
     def test_reserved_characters(self):
         lock = self.obs_lock('some reason @ #night')
 


### PR DESCRIPTION
- 1e511e9c85f8d775b7944a0c2d8128cced91624b:
    obslock: delta.total_seconds() is more resilient than delta.seconds.

- 73f0ed895f4f9c2ff06c6f0765aa86a7d7a30a96:
    obslock: cleanup hold logic and resolve inheriting an expired hold.

Prior to fix the added test failed:

```
Traceback (most recent call last):
  File "/home/jberry/osc-plugin-factory/tests/obslock_tests.py", line 116, in test_expire_hold
    self.assertEqual(reason_sub, None)
AssertionError: 'hold: test' != None
```

Which demonstrates the issue seen in #823.