### PR TITLE
Refactor map_ring_package_to_subject to support corner case

### DIFF
--- a/osclib/stagingapi.py
+++ b/osclib/stagingapi.py
@@ -998,16 +998,16 @@ class StagingAPI(object):
         """
         # it's actually a pretty stupid algorithm, but it might become more complex later
 
-        if project.endswith(':DVD'):
-            return project  # not yet
+        # assuming it is in adi staging, workaround for https://progress.opensuse.org/issues/9646
+        if self.is_adi_project(project):
+            return project
 
-        ring_dvd = '{}:2-TestDVD'.format(self.crings)
-        if self.ring_packages.get(pkg) == ring_dvd:
-            if not self.item_exists(project + ":DVD") and self.item_exists(project, pkg):
-                # assuming it is in adi staging, workaround for https://progress.opensuse.org/issues/9646
-                return project
-            else:
-                return project + ":DVD"
+        if self.ring_packages.get(pkg) and self.rings.index(self.ring_packages.get(pkg)) == 2 and not project.endswith(':DVD'):
+            # pkg A in ring1 and points to pkg B in ring2
+            return project + ":DVD"
+        elif self.ring_packages.get(pkg) and self.rings.index(self.ring_packages.get(pkg)) != 2 and project.endswith(':DVD'):
+            # pkg A in ring2 and points to pkg B in ring1
+            return project.replace(':DVD', '')
 
         return project
 

--- a/tests/api_tests.py
+++ b/tests/api_tests.py
@@ -58,6 +58,7 @@ class TestApiCalls(unittest.TestCase):
         # our content in the XML files
         # test content for listonly ie. list command
         ring_packages = {
+            'apparmor': 'openSUSE:Factory:Rings:1-MinimalX',
             'elem-ring-0': 'openSUSE:Factory:Rings:0-Bootstrap',
             'elem-ring-1': 'openSUSE:Factory:Rings:0-Bootstrap',
             'elem-ring-mini': 'openSUSE:Factory:Rings:0-Bootstrap',
@@ -69,6 +70,7 @@ class TestApiCalls(unittest.TestCase):
 
         # test content for real usage
         ring_packages = {
+            'apparmor': 'openSUSE:Factory:Rings:1-MinimalX',
             'elem-ring-0': 'openSUSE:Factory:Rings:0-Bootstrap',
             'elem-ring-1': 'openSUSE:Factory:Rings:1-MinimalX',
             'elem-ring-mini': 'openSUSE:Factory:Rings:0-Bootstrap',

--- a/tests/fixtures/source/openSUSE:Factory:Rings:1-MinimalX
+++ b/tests/fixtures/source/openSUSE:Factory:Rings:1-MinimalX
@@ -5,4 +5,8 @@
   <sourceinfo package="elem-ring-1" rev="2" vrev="13" srcmd5="1ca04ad54e7de2612ec1f01f46bbc763" lsrcmd5="b4f289282eb01f5812a4ead909215ecf" verifymd5="d4e1ef121637c87f0b6cb6afbeba5758">
     <linked project="openSUSE:Factory" package="elem-ring-1" />
   </sourceinfo>
+  <sourceinfo package="apparmor" rev="1" vrev="5" srcmd5="a19bb8cd73690c7823c0c5bb2076c050" lsrcmd5="c1d67025f343ca222fc4599d8f2ea96f" verifymd5="6c0bc7aa478ab409cfeecd08fad1588b">
+    <filename>apparmor.spec</filename>
+    <linked project="openSUSE:Factory" package="apparmor" />
+  </sourceinfo>
 </sourceinfolist>


### PR DESCRIPTION
We have a corner case that package A in Ring2 and points to package B in Ring1, map_ring_package_to_subject have to handle that as another non-inner project link case, ie. the sub-package link must be created.

https://github.com/openSUSE/osc-plugin-factory/issues/876

With this change:

```
maxlin_factory@tigercity:~> osc api /source/openSUSE:Factory:Staging:G/libunbound-devel-mini?expand=1
<directory name="libunbound-devel-mini" rev="97a63451d3b9e5fbc28d602e186ddd1b" vrev="4" srcmd5="97a63451d3b9e5fbc28d602e186ddd1b">
  <linkinfo project="openSUSE:Factory:Rings:2-TestDVD" package="unbound" srcmd5="4386c97ad0b6541866be8b714a403f37" lsrcmd5="21343c588907214069c013b4886f7c48" />

Selected to :G

maxlin_factory@tigercity:~> osc api /source/openSUSE:Factory:Staging:G/libunbound-devel-mini?expand=1
<directory name="libunbound-devel-mini" rev="bfdd6c3f78b8dbbae0bb05fb9870aae1" vrev="49" srcmd5="bfdd6c3f78b8dbbae0bb05fb9870aae1">
  <linkinfo project="openSUSE:Factory:Staging:G:DVD" package="unbound" srcmd5="67b8be0d6f387480185d738c73abb0ac" lsrcmd5="67223dc56002f8920fbe53a8d8456fb5" />
  <serviceinfo code="succeeded" lsrcmd5="fc019529629327d5289e25c43cd81d0d" />
```