### PR TITLE
cache: correction to match all dashboard file requests.

### DIFF
--- a/osclib/cache.py
+++ b/osclib/cache.py
@@ -84,7 +84,7 @@ class Cache(object):
         # Project will be marked changed when packages are added/removed.
         '/source/([^/]+)/_meta$': TTL_LONG,
         '/source/([^/]+)/(?:[^/]+)/(?:_meta|_link)$': TTL_LONG,
-        '/source/([^/]+)/dashboard/[^/]+\\?expand=1': TTL_LONG,
+        '/source/([^/]+)/dashboard/[^/]+': TTL_LONG,
         # Handles clearing local cache on package deletes. Lots of queries like
         # updating project info, comment, and package additions.
         '/source/([^/]+)/(?:[^/?]+)(?:\?[^/]+)?$': TTL_LONG,


### PR DESCRIPTION
With the query PUTs are not match and thus the local cache is not cleared until the next statistics/latest_updated call.

Overlooked when I made the recent remote config change. Can cause repeat ignores when something like `adi` is run multiple times in < 5 min with multi-source ignore logic (leap).