### PR TITLE
request_splitter: should merge: allow devel and super if not ready.

### DIFF
--- a/osclib/request_splitter.py
+++ b/osclib/request_splitter.py
@@ -177,6 +177,12 @@ class RequestSplitter(object):
         return len(pseudometa['requests']) > 0 and 'splitter_info' in pseudometa
 
     def should_staging_merge(self, status, pseudometa):
+        if (pseudometa['splitter_info']['strategy']['name'] in ('devel', 'super') and
+            status['overall_state'] not in ('acceptable', 'review')):
+            # Simplistic attempt to allow for followup requests to be staged
+            # after age max has been passed while still stopping when ready.
+            return True
+
         if 'activated' not in pseudometa['splitter_info']:
             # No information on the age of the staging.
             return False


### PR DESCRIPTION
Simplistic precursor to #811.

If the consensus is that this is generally alright we can accept, but I can see this not always being the best. For things like KDE updates that are long standing stagings with fixes over a week or more this seems very useful, but for troublesome stagings it may just end up adding more clutter.

For example the proposal generated for Factory at the moment:

```yaml
0#devel@Base:System:
  bootstrap_required: true
  group: Base:System
  merge: true
  requests:
    491274: bash
    492375: rpm
    492649: coreutils
    492807: systemd
  staging: B
  strategy:
    name: devel
1#devel@devel:languages:python3:
  bootstrap_required: false
  group: devel:languages:python3
  merge: true
  requests:
    492721: python3-numba
    492722: python3-llvmlite
    492896: python3-fastcluster
    492900: python3-patsy
    492926: python3-statsmodels
    492932: python3-seaborn
  staging: E
  strategy:
    name: devel
```

Otherwise, can wait for more complex approach trying to see if request might fix something in a staging. The side bonus of this approach being that if a fix takes a day or two to come in other requests can be grouped in and accepted together.

Thoughts?