### PR TITLE
osc-staging: skip lock for observation commands (and other unlock fix).

### DIFF
--- a/osclib/obslock.py
+++ b/osclib/obslock.py
@@ -132,14 +132,22 @@ class OBSLock(object):
             return
 
         user, reason, reason_sub, _ = self._parse(self._read())
+        clear = False
         if user == self.user:
             if reason_sub:
                 self.reason = reason_sub
                 self.reason_sub = None
                 self._write(self._signature())
             elif not reason.startswith('hold') or force:
-                self._write('')
-                self.locked = False
+                # Only clear a command lock as hold can only be cleared by force.
+                clear = True
+        elif user is not None and force:
+            # Clear if a lock is present and force.
+            clear = True
+
+        if clear:
+            self._write('')
+            self.locked = False
 
     def hold(self, message=None):
         self.reason = 'hold'

--- a/tests/obslock_tests.py
+++ b/tests/obslock_tests.py
@@ -122,3 +122,19 @@ class TestOBSLock(unittest.TestCase):
         with lock:
             _, reason, _, _ = lock._parse(lock._read())
             self.assertEqual(reason, 'some reason at hashnight')
+
+    def test_needed(self):
+        lock1 = self.obs_lock()
+        lock2 = self.obs_lock()
+        lock2.user = 'user2'
+        lock2.needed = False
+
+        self.assertFalse(lock1.locked)
+        self.assertFalse(lock2.locked)
+
+        with lock1:
+            self.assertTrue(lock1.locked)
+            with lock2:
+                self.assertFalse(lock2.locked)
+                user, _, _, _ = lock2._parse(lock2._read())
+                self.assertEqual(user, lock1.user, 'lock1 remains')

--- a/tests/obslock_tests.py
+++ b/tests/obslock_tests.py
@@ -125,7 +125,7 @@ class TestOBSLock(unittest.TestCase):
 
     def test_needed(self):
         lock1 = self.obs_lock()
-        lock2 = self.obs_lock()
+        lock2 = self.obs_lock('unlock')
         lock2.user = 'user2'
         lock2.needed = False
 
@@ -138,3 +138,7 @@ class TestOBSLock(unittest.TestCase):
                 self.assertFalse(lock2.locked)
                 user, _, _, _ = lock2._parse(lock2._read())
                 self.assertEqual(user, lock1.user, 'lock1 remains')
+
+                lock2.release(force=True)
+                user, _, _, _ = lock2._parse(lock2._read())
+                self.assertEqual(user, None, 'unlocked')


### PR DESCRIPTION
- 3d7a7d487b4b9ddf1eac2643c47b422213cc0a70:
    obslock: unlock other user lock if force.

- f4523078b45f4f315eac79f93587516b03b100b1:
    **osc-staging: skip lock for observation commands.**

Fixes #886.