### PR TITLE
stagingapi: carry over build state during supersede.

### DIFF
--- a/osclib/stagingapi.py
+++ b/osclib/stagingapi.py
@@ -75,6 +75,8 @@ class StagingAPI(object):
         self._ring_packages_for_links = None
         self._packages_staged = None
         self._package_metas = dict()
+        self._supersede = False
+        self._package_disabled = {}
 
         # If the project support rings, inititialize some variables.
         if self.crings:
@@ -596,6 +598,7 @@ class StagingAPI(object):
             target_requests = []
 
         # get all current pending requests
+        self._supersede = True
         requests = self.get_open_requests()
         requests_ignored = self.get_ignored_requests()
         # check if we can reduce it down by accepting some
@@ -608,6 +611,7 @@ class StagingAPI(object):
             stage_info, code = self.update_superseded_request(rq, target_requests)
             if stage_info:
                 yield (stage_info, code, rq)
+        self._supersede = False
 
     def get_prj_meta(self, project):
         url = make_meta_url('prj', project, self.apiurl)
@@ -760,14 +764,26 @@ class StagingAPI(object):
 
         self._remove_package_from_prj_pseudometa(project, package)
         subprj = self.map_ring_package_to_subject(project, package)
+        if self._supersede:
+            self.is_package_disabled(subprj, package, store=True)
         delete_package(self.apiurl, subprj, package, force=True, msg=msg)
 
         for sub_prj, sub_pkg in self.get_sub_packages(package):
             sub_prj = self.map_ring_package_to_subject(project, sub_pkg)
+            if self._supersede:
+                self.is_package_disabled(sub_prj, sub_pkg, store=True)
             if sub_prj != subprj:  # if different to the main package's prj
                 delete_package(self.apiurl, sub_prj, sub_pkg, force=True, msg=msg)
 
         self.set_review(request_id, project, state=review, msg=msg)
+
+    def is_package_disabled(self, project, package, store=False):
+        meta = show_package_meta(self.apiurl, project, package)
+        meta = ET.fromstring(''.join(meta))
+        disabled = len(meta.xpath('build/disable[not(@*)]')) > 0
+        if store:
+            self._package_disabled['/'.join([project, package])] = disabled
+        return disabled
 
     def create_package_container(self, project, package, disable_build=False):
         """
@@ -1102,6 +1118,9 @@ class StagingAPI(object):
             else:
                 project = self.map_ring_package_to_subject(project, tar_pkg)
 
+            if self._supersede:
+                disable_build = self._package_disabled.get('/'.join([project, tar_pkg]), disable_build)
+
         self.create_package_container(project, tar_pkg,
                                       disable_build=disable_build)
 
@@ -1127,7 +1146,9 @@ class StagingAPI(object):
             # print project, tar_pkg, sub_pkg, sub_prj
             if sub_prj == project:  # skip inner-project links
                 continue
-            self.create_package_container(sub_prj, sub_pkg)
+            if self._supersede:
+                disable_build = self._package_disabled.get('/'.join([sub_prj, sub_pkg]), False)
+            self.create_package_container(sub_prj, sub_pkg, disable_build=disable_build)
 
             root = ET.Element('link', package=tar_pkg, project=project)
             url = self.makeurl(['source', sub_prj, sub_pkg, '_link'])


### PR DESCRIPTION
Allows for packages being added to rings to remain enabled after being superseded.

Likely need to test on a local OBS, build out a supersede test case (not trivial), or cross-fingers.

DO NOT ACCEPT UNTIL SOMEONE HAS HAD A CHANCE TO SEE THIS WORK.

Fixes #896.

Presumably, it is desirable to keep sub package states which is what I did.