### PR TITLE
osc-staging: provide clean_args() to allow for lists containing commas.

### DIFF
--- a/osc-staging.py
+++ b/osc-staging.py
@@ -82,6 +82,19 @@ def lock_needed(cmd, opts):
         (cmd == 'list' and not opts.supersede)
     )
 
+def clean_args(args):
+    out = []
+    for arg in args:
+        if arg == 'and':
+            continue
+        if ' ' not in arg:
+            arg = arg.rstrip(',')
+            if ',' in arg:
+                out.extend(arg.split(','))
+                continue
+        out.append(arg)
+    return out
+
 
 @cmdln.option('--move', action='store_true',
               help='force the selection to become a move')
@@ -327,6 +340,7 @@ def do_staging(self, subcmd, opts, *args):
         min_args, max_args = 0, 0
     else:
         raise oscerr.WrongArgs('Unknown command: %s' % cmd)
+    args = clean_args(args)
     if len(args) - 1 < min_args:
         raise oscerr.WrongArgs('Too few arguments.')
     if max_args is not None and len(args) - 1 > max_args:


### PR DESCRIPTION
Would need to rename `osc-staging` to `osc_staging` to allow import for test. Would be annoying to have to tweak everyone's `~/.osc-plugings`, but does not seem like a bad idea in the long run.

Handles several styles while trying to avoid stripping commas from quoted messages.

```
select --move A pac1, pac2, and pac3
# pac1 pac2 pac3

select --move A pac1,pac2,pac3
# pac1 pac2 pac3

select --move A pac1,pac2,pac3 "a string containing a comma, in it even though it does not make sense"
# pac1 pac2 pac3 [the full untouched string]

unselect -m "a string containing a comma, in it" pac1, and pac2
# pac1 pac2
# message is left alone since option
```

Fixes #892.