### PR TITLE
repo-checker: refactoring to primarily support multiple archs and the Leap workflow

### DIFF
--- a/osc-check_repo.py
+++ b/osc-check_repo.py
@@ -126,14 +126,8 @@ def _check_repo_group(self, id_, requests, skip_cycle=None, debug=False):
     if skip_cycle is None:
         skip_cycle = []
 
-    print '> Check group [%s]' % ', '.join(r.str_compact() for r in requests)
-
     # XXX TODO - If the requests comes from command line, the group is
     # still not there.
-
-    # Do not continue if any of the packages do not successfully build.
-    if not all(self.checkrepo.is_buildsuccess(r) for r in requests if r.action_type != 'delete'):
-        return
 
     toignore = set()
     destdir = os.path.join(BINCACHE, str(requests[0].group))
@@ -578,7 +572,13 @@ def do_check_repo(self, subcmd, opts, *args):
     # Sort the groups, from high to low. This put first the stating
     # projects also
     for id_, reqs in sorted(groups.items(), reverse=True):
+        print '> Check group [%s]' % ', '.join(r.str_compact() for r in requests)
+
         try:
+            # Do not continue if any of the packages do not successfully build.
+            if not all(self.checkrepo.is_buildsuccess(r) for r in reqs if r.action_type != 'delete'):
+                return
+
             self._check_repo_group(id_, reqs,
                                    skip_cycle=opts.skipcycle,
                                    debug=opts.verbose)

--- a/osc-check_repo.py
+++ b/osc-check_repo.py
@@ -161,13 +161,13 @@ def _check_repo_group(self, id_, requests, skip_cycle=None, debug=False):
 
     # Extend packs array with the packages and .spec files of the
     # not-fetched requests.  The not fetched ones are the requests of
-    # the same group that are not listed as a paramater.
+    # the same group that is not listed as a parameter.
     for request_id, is_fetched in fetched.items():
         if not is_fetched:
             packs.extend(self.checkrepo.check_specs(request_id=request_id))
 
     # Download the repos from the request of the same group not
-    # explicited in the command line.
+    # explicit in the command line.
     for rq in packs[:]:
         if rq.request_id in fetched and fetched[rq.request_id]:
             continue
@@ -180,7 +180,7 @@ def _check_repo_group(self, id_, requests, skip_cycle=None, debug=False):
             error_delete = self.checkrepo.is_safe_to_delete(rq)
             if error_delete:
                 rq.error = 'This delete request is not safe to accept yet, ' \
-                           'please wait until the reasons dissapear in the ' \
+                           'please wait until the reasons disappear in the ' \
                            'target project. %s' % error_delete
                 print ' - %s' % rq.error
                 self.checkrepo.change_review_state(request.request_id, 'new', message=request.error)
@@ -190,7 +190,7 @@ def _check_repo_group(self, id_, requests, skip_cycle=None, debug=False):
                 print 'ACCEPTED', msg
                 self.checkrepo.change_review_state(rq.request_id, 'accepted', message=msg)
 
-            # Remove it from the packs, so do not interfere with the
+            # Remove it from the packs, so it does not interfere with the
             # rest of the check.
             packs.remove(rq)
         else:
@@ -199,7 +199,7 @@ def _check_repo_group(self, id_, requests, skip_cycle=None, debug=False):
             self.checkrepo.is_buildsuccess(rq)
             i = self._check_repo_download(rq)
             if rq.error:
-                print 'ERROR (ALREADY ACEPTED?):', rq.error
+                print 'ERROR (ALREADY ACCEPTED?):', rq.error
                 rq.updated = True
 
         toignore.update(i)
@@ -216,7 +216,7 @@ def _check_repo_group(self, id_, requests, skip_cycle=None, debug=False):
             print ' - New edges:', new_edges
 
             if skip_cycle:
-                print ' - Skiping this cycle and moving to the next check.'
+                print ' - Skipping this cycle and moving to the next check.'
                 continue
             else:
                 print ' - If you want to skip this cycle, run manually the ' \
@@ -248,7 +248,7 @@ def _check_repo_group(self, id_, requests, skip_cycle=None, debug=False):
                 package = '#[%s](%s)' % (request, package)
             smissing.append(package)
         if len(smissing):
-            msg = 'Please make sure to wait before these depencencies are in %s: %s [%s]' % (
+            msg = 'Please make sure to wait before these dependencies are in %s: %s [%s]' % (
                 rq.tgt_project, ', '.join(smissing), rq.tgt_package)
             if not rq.updated:
                 self.checkrepo.change_review_state(rq.request_id, 'new', message=msg)
@@ -578,7 +578,7 @@ def do_check_repo(self, subcmd, opts, *args):
                                    skip_cycle=opts.skipcycle,
                                    debug=opts.verbose)
         except Exception as e:
-            print 'ERROR -- An exception happends while checking a group [%s]' % e
+            print 'ERROR -- An exception happened while checking a group [%s]' % e
             if conf.config['debug']:
                 print traceback.format_exc()
         print

--- a/osc-check_repo.py
+++ b/osc-check_repo.py
@@ -426,7 +426,8 @@ def _check_repo_group(self, id_, requests, skip_cycle=None, debug=False):
         if not hasattr(rq, 'goodrepo'):
             msg = 'Can not find a good repo for %s' % rq.str_compact()
             print 'NOT ACCEPTED - ', msg
-            print 'Perhaps this request is not against i586/x86_64 build or i586 build only. For human to check!'
+            print 'Perhaps this request is not against {}. For human to check!'.format(
+                ', '.join(self.repochecker.target_archs()))
             continue
         msg = 'Builds for repo %s' % rq.goodrepo
         print 'ACCEPTED', msg

--- a/osclib/checkrepo.py
+++ b/osclib/checkrepo.py
@@ -458,7 +458,7 @@ class CheckRepo(object):
         elif rq.tgt_package in specs:
             specs.remove(rq.tgt_package)
         else:
-            msg = 'The name of the SPEC files %s do not match with the name of the package (%s)'
+            msg = 'The name of the SPEC files %s do not match the name of the package (%s)'
             msg = msg % (specs, rq.src_package)
             print('[DECLINED]', msg)
             self.change_review_state(request_id, 'declined', message=msg)
@@ -554,7 +554,7 @@ class CheckRepo(object):
                                                request.verifymd5)
         except urllib2.HTTPError as e:
             if 300 <= e.code <= 499:
-                print ' - The request is not built agains this project'
+                print ' - The request is not built against this project'
                 return repos_to_check
             raise e
 
@@ -721,7 +721,7 @@ class CheckRepo(object):
     def check_disturl(self, request, filename=None, md5_disturl=None):
         """Try to match the srcmd5 of a request with the one in the RPM package."""
         if not filename and not md5_disturl:
-            raise ValueError('Please, procide filename or md5_disturl')
+            raise ValueError('Please, provide filename or md5_disturl')
 
         # ugly workaround here, glibc.i686 had a topadd block in _link, and looks like
         # it causes the disturl won't consistently with glibc even with the same srcmd5

--- a/osclib/checkrepo.py
+++ b/osclib/checkrepo.py
@@ -28,6 +28,7 @@ from osc.core import http_DELETE
 from osc.core import http_GET
 from osc.core import http_POST
 from osc.core import makeurl
+from osclib.core import maintainers_get
 from osclib.stagingapi import StagingAPI
 from osclib.memoize import memoize
 from osclib.pkgcache import PkgCache
@@ -965,15 +966,6 @@ class CheckRepo(object):
             deps.update(pkgdep.text for pkgdep in root.findall('.//pkgdep'))
         return deps
 
-    def _maintainers(self, request):
-        """Get the maintainer of the package involved in the request."""
-        query = {
-            'binary': request.tgt_package,
-        }
-        url = makeurl(self.apiurl, ('search', 'owner'), query=query)
-        root = ET.parse(http_GET(url)).getroot()
-        return [p.get('name') for p in root.findall('.//person') if p.get('role') == 'maintainer']
-
     def _author(self, request):
         """Get the author of the request."""
         query = {
@@ -1009,7 +1001,7 @@ class CheckRepo(object):
         """
         reasons = []
         whatdependson = self._whatdependson(request)
-        maintainers = self._maintainers(request)
+        maintainers = maintainers_get(self.apiurl, request.tgt_project, request.tgt_package)
         author = self._author(request)
         prj_maintainers = self._project_maintainer(request)
 

--- a/osclib/checkrepo.py
+++ b/osclib/checkrepo.py
@@ -851,9 +851,9 @@ class CheckRepo(object):
             return True
 
         if alldisabled:
-            msg = '%s is disabled or does not build against factory. Please fix and resubmit' % request.src_package
-            print '[DECLINED]', msg
-            self.change_review_state(request.request_id, 'declined', message=msg)
+            msg = '%s is disabled or does not build against the target project.' % request.src_package
+            print msg
+            self.change_review_state(request.request_id, 'new', message=msg)
             # Next line not needed, but for documentation
             request.updated = True
             return False

--- a/osclib/checkrepo.py
+++ b/osclib/checkrepo.py
@@ -672,16 +672,13 @@ class CheckRepo(object):
     def _toignore(self, request):
         """Return the list of files to ignore during the checkrepo."""
         toignore = set()
-        for fn in self.get_package_list_from_repository(
-                request.tgt_project, 'standard', 'x86_64', request.tgt_package):
-            if fn[1]:
-                toignore.add(fn[1])
+        for arch in self.target_archs():
+            for fn in self.get_package_list_from_repository(
+                request.tgt_project, 'standard', arch, request.tgt_package):
+                # On i586 only exclude -32bit packages.
+                if fn[1] and (arch != 'i586' or fn[2] == 'x86_64'):
+                    toignore.add(fn[1])
 
-        # now fetch -32bit pack list
-        for fn in self.get_package_list_from_repository(
-                request.tgt_project, 'standard', 'i586', request.tgt_package):
-            if fn[1] and fn[2] == 'x86_64':
-                toignore.add(fn[1])
         return toignore
 
     def _disturl(self, filename):

--- a/osclib/checkrepo.py
+++ b/osclib/checkrepo.py
@@ -760,7 +760,7 @@ class CheckRepo(object):
             return False
 
         if not repos_to_check:
-            msg = 'Missing i586 and x86_64 in the repo list'
+            msg = 'Missing {} in the repo list'.format(', '.join(self.target_archs()))
             print ' - %s' % msg
             self.change_review_state(request.request_id, 'new', message=msg)
             # Next line not needed, but for documentation.

--- a/osclib/checkrepo.py
+++ b/osclib/checkrepo.py
@@ -22,6 +22,7 @@ import urllib2
 from xml.etree import cElementTree as ET
 from pprint import pformat
 
+import osc.core
 from osc.core import get_binary_file
 from osc.core import http_DELETE
 from osc.core import http_GET
@@ -591,6 +592,17 @@ class CheckRepo(object):
                     repos_to_check.append(repo)
 
         return repos_to_check
+
+    @memoize(session=True)
+    def target_archs(self, project=None):
+        if not project: project = self.project
+
+        meta = osc.core.show_project_meta(self.apiurl, project)
+        meta = ET.fromstring(''.join(meta))
+        archs = []
+        for arch in meta.findall('repository[@name="standard"]/arch'):
+            archs.append(arch.text)
+        return archs
 
     def is_binary(self, project, repository, arch, package):
         """Return True if is a binary package."""

--- a/osclib/checkrepo.py
+++ b/osclib/checkrepo.py
@@ -772,6 +772,7 @@ class CheckRepo(object):
         foundbuilding = None
         foundfailed = None
 
+        archs_target = self.target_archs()
         for repository in repos_to_check:
             repo_name = repository.attrib['name']
             self.debug("checking repo", ET.tostring(repository))
@@ -781,10 +782,10 @@ class CheckRepo(object):
             r_foundfailed = None
             missings = []
             for arch in repository.findall('arch'):
-                if arch.attrib['arch'] not in ('i586', 'x86_64'):
+                if arch.attrib['arch'] not in archs_target:
                     continue
                 if arch.attrib['result'] == 'excluded':
-                    if ((arch.attrib['arch'] == 'x86_64' and request.src_package not in request.i686_only) or
+                    if ((arch.attrib['arch'] != 'i586' and request.src_package not in request.i686_only) or
                        (arch.attrib['arch'] == 'i586' and request.src_package in request.i686_only)):
                         request.build_excluded = True
                 if 'missing' in arch.attrib:
@@ -812,7 +813,7 @@ class CheckRepo(object):
                 # and the build state per srcmd5 was outdated also.
                 if request.src_package == 'glibc.i686':
                     if ((arch.attrib['arch'] == 'i586' and arch.attrib['result'] == 'outdated') or
-                       (arch.attrib['arch'] == 'x86_64' and arch.attrib['result'] == 'excluded')):
+                       (arch.attrib['arch'] != 'i586' and arch.attrib['result'] == 'excluded')):
                         isgood = True
                         continue
                 if arch.attrib['result'] == 'outdated':

--- a/osclib/checkrepo.py
+++ b/osclib/checkrepo.py
@@ -931,7 +931,7 @@ class CheckRepo(object):
             'package': request.tgt_package,
             'view': 'revpkgnames',
         }
-        for arch in ('i586', 'x86_64'):
+        for arch in self.target_archs():
             url = makeurl(self.apiurl, ('build', request.tgt_project, 'standard', arch, '_builddepinfo'),
                           query=query)
             root = ET.parse(http_GET(url)).getroot()
@@ -944,7 +944,7 @@ class CheckRepo(object):
         query = {
             'package': package,
         }
-        for arch in ('i586', 'x86_64'):
+        for arch in self.target_archs():
             url = makeurl(self.apiurl, ('build', project, 'standard', arch, '_builddepinfo'),
                           query=query)
             root = ET.parse(http_GET(url)).getroot()

--- a/osclib/core.py
+++ b/osclib/core.py
@@ -1,0 +1,28 @@
+import osc.core
+from osc.core import makeurl
+from osc.core import http_GET
+
+from osclib.memoize import memoize
+
+from xml.etree import cElementTree as ET
+
+
+@memoize(session=True)
+def owner_fallback(apiurl, project, package):
+    root = osc.core.owner(apiurl, package, project=project)
+    owner = root.find('owner')
+    if not owner or owner.get('project') == project:
+        # Fallback to global (ex Factory) maintainer.
+        root = osc.core.owner(apiurl, package)
+    return root
+
+def maintainers_get(apiurl, project, package):
+    """Get the maintainer of the package involved in the package."""
+    root = owner_fallback(apiurl, project, package)
+    maintainers = [p.get('name') for p in root.findall('.//person') if p.get('role') == 'maintainer']
+    if not maintainers:
+        for group in [p.get('name') for p in root.findall('.//group') if p.get('role') == 'maintainer']:
+            url = makeurl(apiurl, ('group', group))
+            root = ET.parse(http_GET(url)).getroot()
+            maintainers = maintainers + [p.get('userid') for p in root.findall('./person/person')]
+    return maintainers


### PR DESCRIPTION
The commits provide a fairly good summary of the changes. I have been running the code on a variety of requests against Leap and Factory while developing. Today I cleaned up the code and split into proper commits. As such I will be running some more requests through the checker tomorrow.

Given that `i586` is now checked this does cause new failures in Factory that were not noticed before. Additionally, with the drop of the complex repo logic in `repositories_to_check()` it would be a good idea for any known complex repos to be checked. Let me know if you run any requests and they work properly or have issues. I would suggest we hold off on merging until we are confident this works in a variety of cases in which everyone is comfortable.

This also contains the first bits of `osclib.core` explained by commit and resolves the long standing todo to share the maintainers lookup call. Since I recently enhanced that code to support "local devel" projects for packages like `kernel-source` in Leap it makes sense to ensure repo-checker utilizes those enhancements.

I postponed the rework of the output into the project level comment. I figure if the spammy nature was acceptable before it will be now. Better the limit the number of core changes in one round, but worth revisiting once this settles.

If one is going to thoroughly review I would suggests the commits as they are broken down into small atomic units.

- 34f1ecb6f629de7075e8a0205321e98c4d105660:
    core: extract maintainers_get(), owner_fallback() from MaintenanceChecker.
    
    Allows the code to be properly shared between checkrepo and
    check_maintenance_incidents as a todo suggests. Given that the majority of
    similar cases for code sharing are extension of osc.core it seems to make
    sense to place them in osclib.core.

- 42d01327f47dd0438585a610a58a57bf880b5eb8:
    checkrepo: wait for accepts for all archs before final review accept.

- 087f86e4f8bcd4e9787a14f786da892b3da46e01:
    osc-check_repo: rework primary calls to loop over archs.

- 9c84653a39a38c1449372f55848fdeb22f6f6c27:
    osc-check_repo: protect staging project checks with arch conditions.

- d7570c6c05bdb45652d61c009b7cb7066affabaf:
    osc-check_repo: extract is_buildsuccess() check before _check_repo_group().
    
    _check_repo_group() will become arch specific and is_buildsuccess() already
    checks all applicable archs and does not need to be run multiple times.

- c18b622f18467aa9733aaea202460e1f75fa2900:
    osc-check_repo: mirror all archs.

- fbcab6b68fa0f08679b1e03886965fc3ae01e000:
    checkrepo: convert remaining messages to use target_archs().

- 684ab55ff960fa328130ee756b5c1739fdee991a:
    checkrepo: _whatdependson() and _builddepinfo(): utilize target_archs().

- 48e7d62c23c22980b57a49543f3da55dc4985267:
    checkrepo: is_buildsuccess(): utilize target_archs().

- c77a06d36155e5247b23bb0c535ec5085814447a:
    checkrepo: _toignore(): compress into arch loop.

- 0f5c889fd574267f8d3eacb6b45c0c4096e47e45:
    checkrepo: repositories_to_check(): utilize target_archs().
    
    Drastically simplify the logic while keeping the core the same and
    utilizing archs from project instead of hard-coded.

- 79144beee2392546cd68e249cb09d5bc186422c8:
    checkrepo: utilize the devel project for requests from Factory.
    
    Assuming requests are forwarded to Leap after being accepted into Factory
    the devel project can be reviewed just as when the requests were submitted
    to Factory.

- f09fdd0660fbeab9ed54cf51aeed9328ec3f95b9:
    checkrepo: provide target_archs() method to determine relevant archs.
    
    The default behavior is to return the archs for which the target project
    is built against, but can be used to check any project (like stagings).

- b8973f5e822d5f277f22b870b8cb994cdfc47d5b:
    checkrepo: do not decline for disabled builds.
    
    This behavior is inconsistent in that no builds is ignored, but builds that
    are disabled results in a decline. In order to allow for the request to be
    evaluated in staging it should not be declined so early.

- fcb1c64598a2069d9a91531da51c2fb3cdc07610:
    checkrepo: some spelling and grammar fixes.

Fixes #837 and #764.