### PR TITLE
check_tags: accept immediately if tags instead of waiting for Factory.

### DIFF
--- a/check_tags_in_requests.py
+++ b/check_tags_in_requests.py
@@ -128,10 +128,11 @@ by OBS on which this bot relies.
         return factory_ok
 
     def checkTagNotRequiredOrInRequest(self, req, a):
-        r = self.checkTagNotRequired(req, a)
-        if r != False:
-            return r
-        return self.checkTagInRequest(req, a)
+        tags = self.checkTagInRequest(req, a)
+        if tags is True:
+            return True
+
+        return self.checkTagNotRequired(req, a)
 
     def check_action_submit(self, req, a):
         return self.checkTagNotRequiredOrInRequest(req, a)


### PR DESCRIPTION
Fallback to leaper which can wait for Factory submission.

I believe this does what was requested, but one should double check that the logic matches your intent. This will now accept any new package or one with tags. Otherwise, it will fallback and only accept if in Factory.

Fixes #900.