### PR TITLE
unslect: --cleanup handle superseded request that is never replaced.

### DIFF
--- a/osclib/unselect_command.py
+++ b/osclib/unselect_command.py
@@ -21,8 +21,10 @@ class UnselectCommand(object):
 
     @staticmethod
     def filter_obsolete(request, updated_delta):
-        if request['superseded_by_id'] is not None:
-            return False
+        if request['state'] == 'superseded':
+            # Allow for cases where a request is superseded, but a newer request
+            # is never staged due all newer requests being superseded/declined.
+            return updated_delta.days >= UnselectCommand.cleanup_days
 
         if (request['state'] == 'revoked' or
            (request['state'] == 'declined' and (

--- a/tests/fixtures/project/staging_projects/openSUSE:Factory.json
+++ b/tests/fixtures/project/staging_projects/openSUSE:Factory.json
@@ -1780,8 +1780,20 @@
                 "creator": "alois",
                 "created_at": "2017-05-02T10:24:19.000Z",
                 "package": "Photini",
-                "updated_at": "2017-05-02T17:14:31.000Z",
+                "updated_at": "${update_at_too_recent}",
                 "number": 492437,
+                "state": "superseded",
+                "id": 697437
+            },
+            {
+                "accept_at": null,
+                "superseded_by_id": 592518,
+                "description": "",
+                "creator": "alois",
+                "created_at": "2017-05-02T10:24:19.000Z",
+                "package": "Photini2",
+                "updated_at": "${declined_updated_at_over}",
+                "number": 592437,
                 "state": "superseded",
                 "id": 697437
             },

--- a/tests/unselect_tests.py
+++ b/tests/unselect_tests.py
@@ -18,6 +18,7 @@ class TestUnselect(unittest.TestCase):
         UnselectCommand.config_init(self.api)
         obsolete = self.api.project_status_requests('obsolete', UnselectCommand.filter_obsolete)
         self.assertTrue('492438' in obsolete, 'revoked')
+        self.assertTrue('592437' in obsolete, 'superseded but over threshold')
         self.assertTrue('492439' in obsolete, 'declined by leaper')
         self.assertTrue('492441' in obsolete, 'declined but over threshold')
-        self.assertEqual(len(obsolete), 3)
+        self.assertEqual(len(obsolete), 4)


### PR DESCRIPTION
- [492287](https://build.opensuse.org/request/show/492287)
  - superseded by [494593](https://build.opensuse.org/request/show/494593), but declined

Such requests will never be unselected since the request is `superseded`. This still allows for requests to be reopened or the supersede chain continued while eventually cleaning it up if left to languish.