### PR TITLE
Fix wrong parsing from root

### DIFF
--- a/check_source.py
+++ b/check_source.py
@@ -216,7 +216,7 @@ class CheckSource(ReviewBot.ReviewBot):
             return None
 
         # Decline the delete request against linked package.
-        links = root.findall('linked')
+        links = root.findall('sourceinfo/linked')
         if links is None or len(links) == 0:
             if not self.skip_add_reviews and self.repo_checker is not None:
                 self.add_review(self.request, by_user=self.repo_checker, msg='Is this delete request safe?')


### PR DESCRIPTION
It's a regression from https://github.com/openSUSE/osc-plugin-factory/commit/8db3461a00784e999cb3218c70d16a10b2e70f38

``show_project_sourceinfo`` is returned a string of `sourceinfolist` element. ie.

```
<sourceinfolist>
  <sourceinfo XXX >
    <linked XXX/>
  </sourceinfo>
</sourceinfolist>
```