### PR TITLE
stagingapi: handle old source removed and assume supersede.

### DIFF
--- a/osclib/stagingapi.py
+++ b/osclib/stagingapi.py
@@ -506,6 +506,10 @@ class StagingAPI(object):
                 source_info_new = self.source_info_request(request_new)
                 source_info_old = self.source_info_request(request_old)
 
+                if source_info_old is None:
+                    # Old source was removed thus new request likely to replace.
+                    return stage_info, None
+
                 source_same = source_info_new.get('verifymd5') == source_info_old.get('verifymd5')
                 message = 'sr#{} has {} source and is already staged'.format(
                     request_old.get('id'), 'same' if source_same else 'different')


### PR DESCRIPTION
I noticed `staging-bot` crashed in logs and was able to reproduce locally.
```
Traceback (most recent call last):
  File "/usr/bin/osc", line 41, in <module>
    r = babysitter.run(osccli)
  File "/usr/lib/python2.7/site-packages/osc/babysitter.py", line 61, in run
    return prg.main(argv)
  File "/usr/lib/python2.7/site-packages/osc/cmdln.py", line 343, in main
    return self.cmd(args)
  File "/usr/lib/python2.7/site-packages/osc/cmdln.py", line 366, in cmd
    retval = self.onecmd(argv)
  File "/usr/lib/python2.7/site-packages/osc/cmdln.py", line 500, in onecmd
    return self._dispatch_cmd(handler, argv)
  File "/usr/lib/python2.7/site-packages/osc/cmdln.py", line 1230, in _dispatch_cmd
    return handler(argv[0], opts, *args)
  File "/home/jberry/.osc-plugins/osc-staging.py", line 597, in do_staging
    SupersedeCommand(api).perform(args[1:])
  File "/home/jberry/.osc-plugins/osclib/supersede_command.py", line 15, in perform
    for stage_info, code, request in self.api.dispatch_open_requests(requests):
  File "/home/jberry/.osc-plugins/osclib/stagingapi.py", line 613, in dispatch_open_requests
    stage_info, code = self.update_superseded_request(rq, target_requests)
  File "/home/jberry/.osc-plugins/osclib/stagingapi.py", line 538, in update_superseded_request
    stage_info, code = self.superseded_request(request, target_requests)
  File "/home/jberry/.osc-plugins/osclib/stagingapi.py", line 514, in superseded_request
    source_same = source_info_new.get('verifymd5') == source_info_old.get('verifymd5')
AttributeError: 'NoneType' object has no attribute 'get'
```

Requests in questions:
- [science:HPC / legion (revision 3) to package openSUSE:Factory / legion](https://build.opensuse.org/request/show/499845)
- [science / legion to package openSUSE:Factory / legion](https://build.opensuse.org/request/show/499832)

The second being the older and already staged request which was revoked due to the source being removed as the package changed homes. Clearly in this case the older request should be considered as "not existing" in the sense that the source project is not different since it was moved.

Tested fix locally:
```
request 499845 for legion superseded 499832 in openSUSE:Factory:Staging:adi:165
```