### PR TITLE
stagingapi: update_status_comments() provide diff comments.

### DIFF
--- a/osclib/comments.py
+++ b/osclib/comments.py
@@ -31,7 +31,7 @@ class CommentAPI(object):
         self.apiurl = apiurl
 
     def _prepare_url(self, request_id=None, project_name=None,
-                     package_name=None):
+                     package_name=None, query=None):
         """Prepare the URL to get/put comments in OBS.
 
         :param request_id: Request where to refer the comment.
@@ -41,12 +41,12 @@ class CommentAPI(object):
         """
         url = None
         if request_id:
-            url = makeurl(self.apiurl, ['comments', 'request', request_id])
+            url = makeurl(self.apiurl, ['comments', 'request', request_id], query)
         elif project_name and package_name:
             url = makeurl(self.apiurl, ['comments', 'package', project_name,
-                                        package_name])
+                                        package_name], query)
         elif project_name:
-            url = makeurl(self.apiurl, ['comments', 'project', project_name])
+            url = makeurl(self.apiurl, ['comments', 'project', project_name], query)
         else:
             raise ValueError('Please, set request_id, project_name or / and package_name to add a comment.')
         return url

--- a/osclib/comments.py
+++ b/osclib/comments.py
@@ -84,12 +84,6 @@ class CommentAPI(object):
 
     def comment_find(self, comments, bot, info_match=None):
         """Return previous bot comments that match criteria."""
-
-        def chunks(l, n):
-            """Yield successive n-sized chunks from l."""
-            for i in xrange(0, len(l), n):
-                yield l[i:i + n]
-
         # Case-insensitive for backwards compatibility.
         bot = bot.lower()
         for c in comments.values():

--- a/osclib/comments.py
+++ b/osclib/comments.py
@@ -124,7 +124,7 @@ class CommentAPI(object):
         return marker + '\n\n' + comment
 
     def add_comment(self, request_id=None, project_name=None,
-                    package_name=None, comment=None):
+                    package_name=None, comment=None, parent_id=None):
         """Add a comment in an object in OBS.
 
         :param request_id: Request where to write a comment.
@@ -136,7 +136,10 @@ class CommentAPI(object):
         if not comment:
             raise ValueError('Empty comment.')
 
-        url = self._prepare_url(request_id, project_name, package_name)
+        query = {}
+        if parent_id:
+            query['parent_id'] = parent_id
+        url = self._prepare_url(request_id, project_name, package_name, query)
         return http_POST(url, data=comment)
 
     def delete(self, comment_id):

--- a/osclib/stagingapi.py
+++ b/osclib/stagingapi.py
@@ -626,14 +626,14 @@ class StagingAPI(object):
         return data
 
     @memoize(ttl=60, session=True, add_invalidate=True)
-    def get_prj_pseudometa(self, project):
+    def get_prj_pseudometa(self, project, revision=None):
         """
         Gets project data from YAML in project description
         :param project: project to read data from
         :return structured object with metadata
         """
 
-        root = self.get_prj_meta(project)
+        root = self.get_prj_meta(project, revision)
         description = root.find('description')
         # If YAML parsing fails, load default
         # FIXME: Better handling of errors

--- a/osclib/stagingapi.py
+++ b/osclib/stagingapi.py
@@ -32,6 +32,7 @@ from osc import oscerr
 from osc.core import show_package_meta
 from osc.core import change_review_state
 from osc.core import delete_package
+from osc.core import get_commitlog
 from osc.core import get_group
 from osc.core import get_request
 from osc.core import make_meta_url
@@ -609,6 +610,11 @@ class StagingAPI(object):
             stage_info, code = self.update_superseded_request(rq, target_requests)
             if stage_info:
                 yield (stage_info, code, rq)
+
+    def get_prj_meta_revision(self, project):
+        log = get_commitlog(self.apiurl, project, '_project', None, format='xml', meta=True)
+        root = ET.fromstring(''.join(log))
+        return int(root.find('logentry').get('revision'))
 
     def get_prj_meta(self, project, revision=None):
         meta = show_project_meta(self.apiurl, project, rev=revision)

--- a/osclib/stagingapi.py
+++ b/osclib/stagingapi.py
@@ -40,6 +40,7 @@ from osc.core import http_GET
 from osc.core import http_POST
 from osc.core import http_PUT
 from osc.core import rebuild
+from osc.core import show_project_meta
 from osc.core import streamfile
 
 from osclib.cache import Cache
@@ -609,10 +610,9 @@ class StagingAPI(object):
             if stage_info:
                 yield (stage_info, code, rq)
 
-    def get_prj_meta(self, project):
-        url = make_meta_url('prj', project, self.apiurl)
-        f = http_GET(url)
-        return ET.parse(f).getroot()
+    def get_prj_meta(self, project, revision=None):
+        meta = show_project_meta(self.apiurl, project, rev=revision)
+        return ET.fromstring(''.join(meta))
 
     def load_prj_pseudometa(self, description_text):
         try:

--- a/tests/select_tests.py
+++ b/tests/select_tests.py
@@ -53,19 +53,19 @@ class TestSelect(unittest.TestCase):
         # Only one comment is added
         self.assertEqual(len(first_select_comments), len(comments) + 1)
         # With the right content
-        self.assertTrue('Request#123 for package gcc submitted by @Admin' in first_select_comment['comment'])
+        self.assertTrue('request#123 for package gcc submitted by @Admin' in first_select_comment['comment'])
 
         # Second select
         self.assertEqual(True, SelectCommand(self.api, staging_b).perform(['puppet']))
         second_select_comments = c_api.get_comments(project_name=staging_b)
         last_id = sorted(second_select_comments.keys())[-1]
         second_select_comment = second_select_comments[last_id]
-        # The number of comments remains, but they are different
-        self.assertEqual(len(second_select_comments), len(first_select_comments))
+        # The number of comments increased by one
+        self.assertEqual(len(second_select_comments) - 1, len(first_select_comments))
         self.assertNotEqual(second_select_comment['comment'], first_select_comment['comment'])
-        # The new comments contents both old and new information
-        self.assertTrue('Request#123 for package gcc submitted by @Admin' in second_select_comment['comment'])
-        self.assertTrue('Request#321 for package puppet submitted by @Admin' in second_select_comment['comment'])
+        # The new comments contains new, but not old
+        self.assertFalse('request#123 for package gcc submitted by @Admin' in second_select_comment['comment'])
+        self.assertTrue('added request#321 for package puppet submitted by @Admin' in second_select_comment['comment'])
 
     def test_no_matches(self):
         # search for requests


### PR DESCRIPTION
- 33cad7287de926570868ad8100fcb10a7205efef:
    stagingapi: update_status_comments() provide diff comments.
    
    Instead of always providing a full comment whenever packages are added
    an original comment will be posted and diff comments will be replied to
    the original comment. The diff comments will provide a summary of what
    changed while the complete state can be seen in the project pseudometa.

- 4e6cf006ddaa64c6a69a66509666fbefeed17483:
    stagingapi: provide get_prj_meta_revision().

- 204d58e46515a31db2f0cf6f11a830a9bb98a044:
    stagingapi: update_status_comments() utilize newer comment APIs.
    
    - comment_find()
    - add_marker()

- 4abbd8900ef7b0b4b07d19e18092df4f8503b702:
    stagingapi: get_prj_pseudometa() provide revision parameter.

- 5f2d2f291084d6c7e3a90652238ed6b8c72a3563:
    stagingapi: get_prj_meta() provide revision parameter.

- 2ab9f11d3c6397fcef09fc15fceb87c8b28bb57f:
    comments: provide parent_id parameter for add_comment().

- 441b29d3ebe0228f550193d89da584a1fe782fa6:
    comments: remove unused chunks() from comment_find().

- 7720b96a10778dcc83ae50cc1d85f7653c30b450:
    comments: add query parameter to _prepare_url().

Fixes #749.
Fixes #932.