### PR TITLE
Fix suppkg_rebuild crash

### DIFF
--- a/suppkg_rebuild.py
+++ b/suppkg_rebuild.py
@@ -159,6 +159,7 @@ class StagingHelper(object):
                 stg.find('supportpkg').text = new_suppkg_list
             elif not len(cand_sources[stgname]):
                 stg.find('rebuild').text = 'unneeded'
+                stg.find('supportpkg').text = ''
 
             if stg.find('rebuild').text == 'needed':
                 need_rebuild = True

--- a/suppkg_rebuild.py
+++ b/suppkg_rebuild.py
@@ -131,8 +131,7 @@ class StagingHelper(object):
                     if files.get(pkg) not in cand_sources[stg]:
                         cand_sources[stg].append(files.get(pkg))
 
-        tree = ET.fromstring(rebuild_data)
-        root = tree.getroot()
+        root = ET.fromstring(rebuild_data)
 
         logging.info('Checking rebuild data...')
 


### PR DESCRIPTION
Jun 06 22:51:45 packagelists suppkg_rebuild[25461]: Traceback (most recent call last):
Jun 06 22:51:45 packagelists suppkg_rebuild[25461]:   File "/usr/local/bin/suppkg_rebuild", line 203, in <module>
Jun 06 22:51:45 packagelists suppkg_rebuild[25461]:     sys.exit(main(args))
Jun 06 22:51:45 packagelists suppkg_rebuild[25461]:   File "/usr/local/bin/suppkg_rebuild", line 185, in main
Jun 06 22:51:45 packagelists suppkg_rebuild[25461]:     uc.crawl()
Jun 06 22:51:45 packagelists suppkg_rebuild[25461]:   File "/usr/local/bin/suppkg_rebuild", line 135, in crawl
Jun 06 22:51:45 packagelists suppkg_rebuild[25461]:     root = tree.getroot()
Jun 06 22:51:45 packagelists suppkg_rebuild[25461]: AttributeError: getroot