### PR TITLE
Detect duplicate binaries within a project

### DIFF
--- a/issue-diff.py
+++ b/issue-diff.py
@@ -21,6 +21,7 @@ import osc.conf
 import osc.core
 
 from osclib.cache import Cache
+from osclib.core import package_list
 
 # Issue summary can contain unicode characters and therefore a string containing
 # either summary or one in which ISSUE_SUMMARY is then placed must be unicode.
@@ -203,16 +204,6 @@ def issues_get(apiurl, project, package, trackers, db):
         }
 
     return issues
-
-def package_list(apiurl, project):
-    url = osc.core.makeurl(apiurl, ['source', project], { 'expand': 1 })
-    root = ET.parse(osc.core.http_GET(url)).getroot()
-
-    packages = []
-    for package in root.findall('entry'):
-        packages.append(package.get('name'))
-
-    return sorted(packages)
 
 def git_clone(url, directory):
     return_code = subprocess.call(['git', 'clone', url, directory])

--- a/osc-staging.py
+++ b/osc-staging.py
@@ -35,6 +35,7 @@ from osc import oscerr
 from osclib.accept_command import AcceptCommand
 from osclib.adi_command import AdiCommand
 from osclib.check_command import CheckCommand
+from osclib.check_duplicate_binaries_command import CheckDuplicateBinariesCommand
 from osclib.cleanup_rings import CleanupRings
 from osclib.conf import Config
 from osclib.freeze_command import FreezeCommand
@@ -78,7 +79,7 @@ def _full_project_name(self, project):
 
 def lock_needed(cmd, opts):
     return not(
-        cmd in ('acheck', 'check', 'frozenage', 'rebuild', 'unlock') or
+        cmd in ('acheck', 'check', 'check_duplicate_binaries', 'frozenage', 'rebuild', 'unlock') or
         (cmd == 'list' and not opts.supersede)
     )
 
@@ -134,6 +135,7 @@ def clean_args(args):
 @cmdln.option('--try-strategies', action='store_true', default=False, help='apply strategies and keep any with desireable outcome')
 @cmdln.option('--strategy', help='apply a specific strategy')
 @cmdln.option('--no-color', action='store_true', help='strip colors from output (or add staging.color = 0 to the .oscrc general section')
+@cmdln.option('--save', action='store_true', help='save the result to the dashboard container')
 def do_staging(self, subcmd, opts, *args):
     """${cmd_name}: Commands to work with staging projects
 
@@ -156,6 +158,8 @@ def do_staging(self, subcmd, opts, *args):
         ready, unstaged, and the adi staging deleted.
 
     "check" will check if all packages are links without changes
+
+    "check_duplicate_binaries" list binaries provided by multiple packages
 
     "cleanup_rings" will try to cleanup rings content and print
         out problems
@@ -283,6 +287,7 @@ def do_staging(self, subcmd, opts, *args):
         osc staging acheck
         osc staging adi [--move] [--by-develproject] [--split] [REQUEST...]
         osc staging check [--old] [STAGING...]
+        osc staging check_duplicate_binaries
         osc staging cleanup_rings
         osc staging freeze [--no-boostrap] STAGING...
         osc staging frozenage [STAGING...]
@@ -332,6 +337,7 @@ def do_staging(self, subcmd, opts, *args):
         min_args, max_args = 1, None
     elif cmd in (
         'acheck',
+        'check_duplicate_binaries',
         'cleanup_rings',
         'list',
         'lock',
@@ -385,6 +391,8 @@ def do_staging(self, subcmd, opts, *args):
                 for prj in args[1:]:
                     CheckCommand(api).perform(prj, opts.old)
                     print()
+        elif cmd == 'check_duplicate_binaries':
+            CheckDuplicateBinariesCommand(api).perform(opts.save)
         elif cmd == 'freeze':
             for prj in args[1:]:
                 prj = api.prj_from_letter(prj)

--- a/osclib/check_duplicate_binaries_command.py
+++ b/osclib/check_duplicate_binaries_command.py
@@ -1,0 +1,47 @@
+from __future__ import print_function
+from osc.core import get_binarylist
+from osclib.core import package_list
+from osclib.core import target_archs
+import re
+import yaml
+
+
+class CheckDuplicateBinariesCommand(object):
+    def __init__(self, api):
+        self.api = api
+
+    def perform(self, save=False):
+        duplicates = {}
+        for arch in sorted(target_archs(self.api.apiurl, self.api.project), reverse=True):
+            print('arch {}'.format(arch))
+
+            binaries = {}
+            duplicates[arch] = {}
+            for package in package_list(self.api.apiurl, self.api.project):
+                for binary in get_binarylist(self.api.apiurl, self.api.project,
+                                             'standard', arch, package):
+                    # StagingAPI.fileinfo_ext(), but requires lots of calls.
+                    match = re.match(r'(.*)-([^-]+)-([^-]+)\.([^-\.]+)\.rpm', binary)
+                    if not match or match.group(4) == 'src': continue
+
+                    name = match.group(1)
+                    if name in binaries:
+                        print('DUPLICATE', package, binaries[name], name)
+
+                        if name not in duplicates[arch]:
+                            # Only add the first package found once.
+                            duplicates[arch][name] = [binaries[name]]
+
+                        duplicates[arch][name].append(package)
+                        continue
+
+                    binaries[name] = package
+                    print(package, name)
+
+        if save:
+            args = ['{}:Staging'.format(self.api.project), 'dashboard', 'duplicate_binaries']
+            previous = self.api.load_file_content(*args)
+            current = yaml.dump(duplicates, default_flow_style=False)
+            if current != previous:
+                args.append(current)
+                self.api.save_file_content(*args)

--- a/osclib/core.py
+++ b/osclib/core.py
@@ -2,6 +2,7 @@ from xml.etree import cElementTree as ET
 
 from osc.core import http_GET
 from osc.core import makeurl
+from osc.core import show_project_meta
 
 from osclib.memoize import memoize
 
@@ -15,3 +16,12 @@ def package_list(apiurl, project):
         packages.append(package.get('name'))
 
     return sorted(packages)
+
+@memoize(session=True)
+def target_archs(apiurl, project):
+    meta = show_project_meta(apiurl, project)
+    meta = ET.fromstring(''.join(meta))
+    archs = []
+    for arch in meta.findall('repository[@name="standard"]/arch'):
+        archs.append(arch.text)
+    return archs

--- a/osclib/core.py
+++ b/osclib/core.py
@@ -1,0 +1,17 @@
+from xml.etree import cElementTree as ET
+
+from osc.core import http_GET
+from osc.core import makeurl
+
+from osclib.memoize import memoize
+
+@memoize(session=True)
+def package_list(apiurl, project):
+    url = makeurl(apiurl, ['source', project], { 'expand': 1 })
+    root = ET.parse(http_GET(url)).getroot()
+
+    packages = []
+    for package in root.findall('entry'):
+        packages.append(package.get('name'))
+
+    return sorted(packages)


### PR DESCRIPTION
Fixes https://progress.opensuse.org/issues/17996.

`osc staging list` works to see output.

What is the desired outcome of the command? Doubtful there can be any automated resolution as it will likely require deleting packages. Simply print a list of duplicates?

Seems like we want to integrate with repo checker potentially and a one off command potentially similar to `devel-projects.py` that could generate a map/list in dashboard container to be picked up by repo checker and refreshed nightly. Could enhance to only rescan packages that have been updated.