### PR TITLE
openqa-comment: add headings to avoid paragraph formatting mess.

### DIFF
--- a/openqa-comments.py
+++ b/openqa-comments.py
@@ -161,7 +161,7 @@ class OpenQAReport(object):
             if len(green_lines) > MAX_LINES:
                 green_report += ', and more (%s) ...' % (len(green_lines) - MAX_LINES)
 
-        return '\n'.join((failing_report, green_report)), bool(failing_lines)
+        return '\n'.join((failing_report, green_report)).strip(), bool(failing_lines)
 
     def report(self, project):
         info = self.get_info(project)

--- a/openqa-comments.py
+++ b/openqa-comments.py
@@ -153,7 +153,7 @@ class OpenQAReport(object):
 
         failing_report, green_report = '', ''
         if failing_lines:
-            failing_report = '* Failing openQA tests:\n' + '\n'.join(failing_lines[:MAX_LINES])
+            failing_report = '* Failing tests:\n' + '\n'.join(failing_lines[:MAX_LINES])
             if len(failing_lines) > MAX_LINES:
                 failing_report += '\n  * and more (%s) ...' % (len(failing_lines) - MAX_LINES)
         if green_lines:

--- a/openqa-comments.py
+++ b/openqa-comments.py
@@ -183,6 +183,10 @@ class OpenQAReport(object):
         report_openQA, some_openqa_fail = self._report_openQA(info)
 
         if report_broken_packages or some_openqa_fail:
+            if report_broken_packages:
+                report_broken_packages = 'Broken:\n\n' + report_broken_packages
+            if report_openQA:
+                report_openQA = 'openQA:\n\n' + report_openQA
             report = '\n\n'.join((report_broken_packages, report_openQA))
             report = report.strip()
             if report:


### PR DESCRIPTION
- cd937e1f6141bb7c9beaac5d4bf5648dfae435e8:
    openqa-comment: add headings to avoid paragraph formatting mess.

- c61247240b6ec495d135559a1b3aefac5815fce3:
    openqa-comment: strip whitespace when only one type of openqa report.

The ugly formatting on some comments has bothered me for a while.
```
* Build failed rpm-python ([i586](https://build.opensuse.org/package/live_build_log/openSUSE:Leap:42.3:Staging:B/rpm-python/standard/i586), [x86_64](https://build.opensuse.org/package/live_build_log/openSUSE:Leap:42.3:Staging:B/rpm-python/standard/x86_64))
* Build failed rpm ([i586](https://build.opensuse.org/package/live_build_log/openSUSE:Leap:42.3:Staging:B/rpm/standard/i586), [x86_64](https://build.opensuse.org/package/live_build_log/openSUSE:Leap:42.3:Staging:B/rpm/standard/x86_64))


* Succeeding tests:[minimalx@smp_64](https://openqa.opensuse.org/tests/420497), [RAID1@64bit](https://openqa.opensuse.org/tests/420498), [rescue_system@64bit](https://openqa.opensuse.org/tests/420499), [cryptlvm@64bit](https://openqa.opensuse.org/tests/420500), [staging](https://openqa.opensuse.org/tests/420502), [kde@64bit](https://openqa.opensuse.org/tests/420656), and more (1) ...
```

The issue is the double newline between broken packages and openQA results. OBS then formats the bullet with a paragraph which messes up the formatting. The openQA results also contain a trailing newline which causes the same effect. The end result is:

![image](https://user-images.githubusercontent.com/22943929/27203882-93eee740-51ed-11e7-9240-26f008f8362a.png)

Either squishing the bullets together and removing the trailing space or adding headings resolves the issue. I chose the latter.

![image](https://user-images.githubusercontent.com/22943929/27203906-b0a8ca72-51ed-11e7-9a6b-e69b7a777226.png)