### PR TITLE
Work around wrong sorting of jobs

### DIFF
--- a/openqa-maintenance.py
+++ b/openqa-maintenance.py
@@ -378,8 +378,13 @@ class OpenQABot(ReviewBot.ReviewBot):
     def gather_test_builds(self):
         for prj, u in TARGET_REPO_SETTINGS[self.openqa.baseurl].items():
             buildnr = 0
+            cjob = 0
             for j in self.jobs_for_target(u):
+                # avoid going backwards in job ID
+                if cjob > int(j['id']):
+                   continue
                 buildnr = j['settings']['BUILD']
+                cjob = int(j['id'])
             self.update_test_builds[prj] = buildnr
 
     # reimplemention from baseclass


### PR DESCRIPTION
the /api/v1/jobs route in openQA returns the jobs in the 1, 10, 2, ..., 9 order.
So we need to avoid jumping backwards when we look for the latest build id