### PR TITLE
Fixes loading config file

### DIFF
--- a/ReviewBot.py
+++ b/ReviewBot.py
@@ -30,6 +30,7 @@ from osclib.comments import CommentAPI
 from osclib.memoize import memoize
 import signal
 import datetime
+import yaml
 
 try:
     from xml.etree import cElementTree as ET
@@ -88,9 +89,8 @@ class ReviewBot(object):
 
     def load_config(self, filename = None):
         if filename:
-            fh = open(filename, 'r')
-            self.config = self._load_config(fh)
-            close(fh)
+            with open(filename, 'r') as fh:
+                self.config = self._load_config(fh)
         else:
             self.config = self._load_config()
 


### PR DESCRIPTION
BEFORE: 

```
$ python2 ReviewBot.py --dry -c ./pokus.yml
Traceback (most recent call last):                         
  File "ReviewBot.py", line 575, in <module>               
    sys.exit( app.main() )   
  File "/usr/lib/python2.7/site-packages/cmdln.py", line 251, in main                                                  
    retval = self.postoptparse()                           
  File "ReviewBot.py", line 476, in postoptparse           
    self.checker.load_config(self.options.config)          
  File "ReviewBot.py", line 92, in load_config             
    self.config = self._load_config(fh)                    
  File "ReviewBot.py", line 86, in _load_config            
    y = yaml.safe_load(handle) if handle is not None else {}                                                           
NameError: global name 'yaml' is not defined               
```

