### PR TITLE
dist/ci/deploy.obs.sh: remove previous source.

### DIFF
--- a/dist/ci/deploy.obs.sh
+++ b/dist/ci/deploy.obs.sh
@@ -10,6 +10,7 @@ eom
 osc checkout "$OBS_PACKAGE"
 cd "$OBS_PACKAGE"
 
+rm *.obscpio
 osc service disabledrun
 echo >> _servicedata
 osc addremove


### PR DESCRIPTION
I have this in my normal scripts, but for some reason didn't think it was needed. Minor fix to keep sources from only being added.