### PR TITLE
dist/spec: utilize obs_scm renaming which properly includes version in source (and followups)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 env:
   global:
-    - OBS_PACKAGE="home:jberry:travis/openSUSE-release-tools"
+    - OBS_PACKAGE="openSUSE:Tools/openSUSE-release-tools"
     - OBS_USER="jberry"
     # OBS_PASS
     - secure: "0MI2ZbJ+C1FoOa+rBYq3+NQBoQzE528B1mNacZx5xaH6IipFklW9TlCUSO91Pgf2l72HzNL5GhBbYGtAO9og0tyJO9Vm+7F+AUNQHQjfD46r1MyxBlACi6FGwuR+E32OIFilekJCnNKp55Cl5O2wGWUcRRVlM6/+k24dt3lkIoY="

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ matrix:
 
 deploy:
   provider: script
-  script: docker run -it -e OBS_PACKAGE="$OBS_PACKAGE" -e OBS_USER="$OBS_USER" -e OBS_PASS="$OBS_PASS" spec ./dist/ci/deploy.obs.sh
+  script: docker run -it -e OBS_PACKAGE="$OBS_PACKAGE" -e OBS_USER="$OBS_USER" -e OBS_PASS="$OBS_PASS" -e OBS_EMAIL="$OBS_EMAIL" spec ./dist/ci/deploy.obs.sh
   on:
     branch: master
     condition: $TEST_SUITE = distribution

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ test:
 
 package:
 	touch dist/package/$(package_name).changes
-	tar -cJf dist/package/$(package_name).tar.xz --exclude=.git* --exclude=dist/package/*.tar.xz --transform 's,^\.,$(package_name),' .
+	tar -cJf dist/package/$(package_name)-0.tar.xz --exclude=.git* --exclude=dist/package/*.tar.xz --transform 's,^\.,$(package_name)-0,' .
 
 package-clean:
 	rm -f dist/package/$(package_name).changes

--- a/dist/package/openSUSE-release-tools.spec
+++ b/dist/package/openSUSE-release-tools.spec
@@ -122,6 +122,7 @@ Group:          Development/Tools/Other
 BuildArch:      noarch
 # TODO Update requirements, but for now base deps.
 Requires:       %{name} = %{version}
+Requires:       osc
 
 %description -n osclib
 Supplemental osc libraries utilized by release tools.
@@ -148,6 +149,7 @@ OSC plugin for cycle visualization, see `osc cycle --help`.
 Summary:        OSC plugin for the staging workflow
 Group:          Development/Tools/Other
 BuildArch:      noarch
+Requires:       osc
 Requires:       osclib = %{version}
 
 %description -n osc-plugin-staging

--- a/dist/package/openSUSE-release-tools.spec
+++ b/dist/package/openSUSE-release-tools.spec
@@ -27,8 +27,7 @@ Summary:        Tools to aid in staging and release work for openSUSE/SUSE
 License:        GPL-2.0+ and MIT
 Group:          Development/Tools/Other
 Url:            https://github.com/openSUSE/osc-plugin-factory
-# _service:tar/filename does not seem to add version like docs indicate.
-Source:         %{name}.tar.xz
+Source:         %{name}-%{version}.tar.xz
 BuildArch:      noarch
 BuildRequires:  osc
 BuildRequires:  python-PyYAML
@@ -156,7 +155,7 @@ Requires:       osclib = %{version}
 OSC plugin for the staging workflow, see `osc staging --help`.
 
 %prep
-%setup -q -n "%{name}"
+%setup -q
 
 %build
 make %{?_smp_mflags}

--- a/dist/package/openSUSE-release-tools.spec
+++ b/dist/package/openSUSE-release-tools.spec
@@ -216,6 +216,7 @@ mkdir -p %{buildroot}%{_datadir}/%{source_dir}/%{announcer_filename}
 %doc README.asciidoc
 
 %files abichecker
+%defattr(-,root,root,-)
 %{apache_sysconfdir}/vhosts.d/opensuse-abi-checker.conf.in
 %{_datadir}/%{source_dir}/abichecker
 %{_tmpfilesdir}/opensuse-abi-checker.conf
@@ -231,22 +232,27 @@ mkdir -p %{buildroot}%{_datadir}/%{source_dir}/%{announcer_filename}
 %{_unitdir}/%{announcer_filename}.timer
 
 %files totest-manager
+%defattr(-,root,root,-)
 %{_unitdir}/opensuse-totest-manager.service
 %{_datadir}/%{source_dir}/totest-manager.py
 
 %files -n osclib
+%defattr(-,root,root,-)
 %{_datadir}/%{source_dir}/osclib
 %{osc_plugin_dir}/osclib
 
 %files -n osc-plugin-check_dups
+%defattr(-,root,root,-)
 %{_datadir}/%{source_dir}/osc-check_dups.py
 %{osc_plugin_dir}/osc-check_dups.py
 
 %files -n osc-plugin-cycle
+%defattr(-,root,root,-)
 %{_datadir}/%{source_dir}/osc-cycle.py
 %{osc_plugin_dir}/osc-cycle.py
 
 %files -n osc-plugin-staging
+%defattr(-,root,root,-)
 %{_datadir}/%{source_dir}/osc-staging.py
 %{osc_plugin_dir}/osc-staging.py
 


### PR DESCRIPTION
- 5dde1801da242b02d1a503e9caf804c962dc7786:
    travis: target proper home in openSUSE:Tools for deployment.

- 32aa60bab48a1bd65b64d919d6e8574c583fc450:
    dist/spec: utilize obs_scm renaming which properly includes version in source.

- 651c7d57f136d4f49461a533633c3f093e6ab9a4:
    travis: include OBS_EMAIL environment variable when deploying.

- 95c43d0ce68bd959d54ea7ea34bc98bd297d16fa:
    dist/spec: include %defattr on all %files entries.

- dc07d5980b5a94d736f771c71cbf52dbca423488:
    dist/spec: add missing osc requires.

Just missing SLE deps or branch in proper repo from #1007.