### PR TITLE
dist/ci/deploy.obs.sh: include apiurl in general so email is used during service run.

### DIFF
--- a/dist/ci/Dockerfile
+++ b/dist/ci/Dockerfile
@@ -10,6 +10,8 @@ RUN zypper ar http://mirror.datto.com/opensuse/tumbleweed/repo/oss/ oss2 && \
   zypper lr -U
 
 RUN zypper ref && zypper -n in --no-recommends \
+  obs-service-download_files \
+  obs-service-format_spec_file \
   obs-service-obs_scm \
   obs-service-source_validator \
   rpm-build \

--- a/dist/ci/deploy.obs.sh
+++ b/dist/ci/deploy.obs.sh
@@ -2,6 +2,7 @@
 
 cat << eom > ~/.oscrc
 [general]
+apiurl = https://api.opensuse.org
 [https://api.opensuse.org]
 user = $OBS_USER
 pass = $OBS_PASS


### PR DESCRIPTION
- 8de99935bb9aec86d1bfda2164ff02fa3c2e020e:
    dist/ci/deploy.obs.sh: include apiurl in general so email is used during service run.

- 8df27b1de275505134c012950b70f9bed2ca53bf:
    dist/ci/Dockerfile: include obs-service-{download_files,format_spec_file} for deployment.