### PR TITLE
check_source: change repo_checker default to new OBS username.

### DIFF
--- a/check_source.py
+++ b/check_source.py
@@ -28,7 +28,7 @@ class CheckSource(ReviewBot.ReviewBot):
         self.devel_whitelist_file = os.path.join(CheckSource.SCRIPT_PATH, 'check_source.whitelist')
         self.devel_whitelist = None
         self.review_team = 'opensuse-review-team'
-        self.repo_checker = 'factory-repo-checker'
+        self.repo_checker = 'repo-checker'
         self.staging_group = 'factory-staging'
         self.skip_add_reviews = False
 


### PR DESCRIPTION
To distinguish from the old factory-repo-checker and use a generic name applicable to Leap as well.

Seems like the best plan to use the same user for identical bots to remove any possible confusion by being consistent. There are no other references, outside of tests, in this repo, and I would not expect them elsewhere.