### PR TITLE
Factory test dvd: upgrade to postgresql96

### DIFF
--- a/create_test_Factory_dvd-2.testcase
+++ b/create_test_Factory_dvd-2.testcase
@@ -85,7 +85,7 @@ job install name php5
 job install name apache2-mod_php5
 job install name php5-mysql
 job install name php5-pgsql
-job install name postgresql94-server
+job install name postgresql96-server
 job install name bind
 
 ## required for ppc64 test


### PR DESCRIPTION
Accompanies https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/3171

openQA no longer tests postgresql94, but 96, so we need to follow suite here