### PR TITLE
WIP: Major rework of the openqa bot 

### DIFF
--- a/data/apimap.json
+++ b/data/apimap.json
@@ -17,6 +17,12 @@
         "version" : "12-SP1",
         "flavor"  : "Server-DVD-Incidents"
       },
+      "SUSE:Updates:SLE-SERVER:12-LTSS:"
+      : {
+        "archs" : [ "x86_64", "s390x", "ppc64le" ],
+        "version" : "12",
+        "flavor"  : "Server-DVD-Incidents"
+      },
       "SUSE:Updates:SLE-DESKTOP:12-SP2:"
       : {
         "archs"   : ["x86_64"],

--- a/data/apimap.json
+++ b/data/apimap.json
@@ -10,7 +10,7 @@
    },
    "SUSE:Updates:SLE-DESKTOP:12-SP2:" : {
       "issues" : {
-         "SDK_ISSUES" : "SUSE:Updates:SLE-SDK:12-SP2:"
+         "SDK_TEST_ISSUES" : "SUSE:Updates:SLE-SDK:12-SP2:"
       },
       "version" : "12-SP2",
       "flavor" : "Desktop-DVD-Incidents",
@@ -29,11 +29,11 @@
    },
    "SUSE:Updates:SLE-SERVER:12-SP3:" : {
       "issues" : {
-         "WE_ISSUES" : "SUSE:Updates:SLE-WE:12-SP3:",
-         "TCM_ISSUES" : "SUSE:Maintenance:Test:SLE-Module-Toolchain:12:",
-         "HPCM_ISSUES" : "SUSE:Updates:SLE-Module-HPC:12:",
-         "SDK_ISSUES" : "SUSE:Updates:SLE-SDK:12-SP3:",
-         "WSM_ISSUES" : "SUSE:Maintenance:Test:SLE-Module-Web-Scripting:12:"
+         "WE_TEST_ISSUES" : "SUSE:Updates:SLE-WE:12-SP3:",
+         "TCM_TEST_ISSUES" : "SUSE:Maintenance:Test:SLE-Module-Toolchain:12:",
+         "HPCM_TEST_ISSUES" : "SUSE:Updates:SLE-Module-HPC:12:",
+         "SDK_TEST_ISSUES" : "SUSE:Updates:SLE-SDK:12-SP3:",
+         "WSM_TEST_ISSUES" : "SUSE:Maintenance:Test:SLE-Module-Web-Scripting:12:"
       },
       "flavor" : "Server-DVD-Incidents",
       "version" : "12-SP3",
@@ -47,7 +47,7 @@
    "SUSE:Updates:SLE-DESKTOP:12-SP3:" : {
       "version" : "12-SP3",
       "issues" : {
-         "SDK_ISSUES" : "SUSE:Updates:SLE-SDK:12-SP3:"
+         "SDK_TEST_ISSUES" : "SUSE:Updates:SLE-SDK:12-SP3:"
       },
       "flavor" : "Desktop-DVD-Incidents",
       "archs" : [
@@ -57,11 +57,11 @@
    "SUSE:Updates:SLE-SERVER:12-SP2:" : {
       "version" : "12-SP2",
       "issues" : {
-         "WE_ISSUES" : "SUSE:Updates:SLE-WE:12-SP2:",
-         "TCM_ISSUES" : "SUSE:Maintenance:Test:SLE-Module-Toolchain:12:",
-         "SDK_ISSUES" : "SUSE:Updates:SLE-SDK:12-SP2:",
-         "HPCM_ISSUES" : "SUSE:Updates:SLE-Module-HPC:12:",
-         "WSM_ISSUES" : "SUSE:Maintenance:Test:SLE-Module-Web-Scripting:12:"
+         "WE_TEST_ISSUES" : "SUSE:Updates:SLE-WE:12-SP2:",
+         "TCM_TEST_ISSUES" : "SUSE:Maintenance:Test:SLE-Module-Toolchain:12:",
+         "SDK_TEST_ISSUES" : "SUSE:Updates:SLE-SDK:12-SP2:",
+         "HPCM_TEST_ISSUES" : "SUSE:Updates:SLE-Module-HPC:12:",
+         "WSM_TEST_ISSUES" : "SUSE:Maintenance:Test:SLE-Module-Web-Scripting:12:"
       },
       "flavor" : "Server-DVD-Incidents",
       "archs" : [

--- a/data/apimap.json
+++ b/data/apimap.json
@@ -1,33 +1,74 @@
 {
-    "SUSE:Updates:SLE-SERVER:12-SP2:"
-      : {
-        "archs" : [ "x86_64", "s390x", "ppc64le", "aarch64" ],
-        "version" : "12-SP2",
-        "flavor"  : "Server-DVD-Incidents",
-        "issues"
-        : {
-            "SDK_ISSUES"  : "SUSE:Updates:SLE-SDK:12-SP2:",
-            "HPCM_ISSUES" : "SUSE:Updates:SLE-Module-HPC:12:",
-            "WE_ISSUES"   : "SUSE:Updates:SLE-WE:12-SP2:"
-        }
+   "SUSE:Updates:SLE-SERVER:12-SP1-LTSS:" : {
+      "flavor" : "Server-DVD-Incidents",
+      "version" : "12-SP1",
+      "archs" : [
+         "x86_64",
+         "s390x",
+         "ppc64le"
+      ]
+   },
+   "SUSE:Updates:SLE-DESKTOP:12-SP2:" : {
+      "issues" : {
+         "SDK_ISSUES" : "SUSE:Updates:SLE-SDK:12-SP2:"
       },
-      "SUSE:Updates:SLE-SERVER:12-SP1-LTSS:"
-      : {
-        "archs" : [ "x86_64", "s390x", "ppc64le" ],
-        "version" : "12-SP1",
-        "flavor"  : "Server-DVD-Incidents"
+      "version" : "12-SP2",
+      "flavor" : "Desktop-DVD-Incidents",
+      "archs" : [
+         "x86_64"
+      ]
+   },
+   "SUSE:Updates:SLE-SERVER:12-LTSS:" : {
+      "version" : "12",
+      "flavor" : "Server-DVD-Incidents",
+      "archs" : [
+         "x86_64",
+         "s390x",
+         "ppc64le"
+      ]
+   },
+   "SUSE:Updates:SLE-SERVER:12-SP3:" : {
+      "issues" : {
+         "WE_ISSUES" : "SUSE:Updates:SLE-WE:12-SP3:",
+         "TCM_ISSUES" : "SUSE:Maintenance:Test:SLE-Module-Toolchain:12:",
+         "HPCM_ISSUES" : "SUSE:Updates:SLE-Module-HPC:12:",
+         "SDK_ISSUES" : "SUSE:Updates:SLE-SDK:12-SP3:",
+         "WSM_ISSUES" : "SUSE:Maintenance:Test:SLE-Module-Web-Scripting:12:"
       },
-      "SUSE:Updates:SLE-SERVER:12-LTSS:"
-      : {
-        "archs" : [ "x86_64", "s390x", "ppc64le" ],
-        "version" : "12",
-        "flavor"  : "Server-DVD-Incidents"
+      "flavor" : "Server-DVD-Incidents",
+      "version" : "12-SP3",
+      "archs" : [
+         "x86_64",
+         "s390x",
+         "ppc64le",
+         "aarch64"
+      ]
+   },
+   "SUSE:Updates:SLE-DESKTOP:12-SP3:" : {
+      "version" : "12-SP3",
+      "issues" : {
+         "SDK_ISSUES" : "SUSE:Updates:SLE-SDK:12-SP3:"
       },
-      "SUSE:Updates:SLE-DESKTOP:12-SP2:"
-      : {
-        "archs"   : ["x86_64"],
-        "version" : "12-SP2",
-        "flavor"  : "Desktop-DVD-Incidents",
-        "issues"  : { "SDK_ISSUES" : "SUSE:Updates:SLE-SDK:12-SP2:" }
-      }
+      "flavor" : "Desktop-DVD-Incidents",
+      "archs" : [
+         "x86_64"
+      ]
+   },
+   "SUSE:Updates:SLE-SERVER:12-SP2:" : {
+      "version" : "12-SP2",
+      "issues" : {
+         "WE_ISSUES" : "SUSE:Updates:SLE-WE:12-SP2:",
+         "TCM_ISSUES" : "SUSE:Maintenance:Test:SLE-Module-Toolchain:12:",
+         "SDK_ISSUES" : "SUSE:Updates:SLE-SDK:12-SP2:",
+         "HPCM_ISSUES" : "SUSE:Updates:SLE-Module-HPC:12:",
+         "WSM_ISSUES" : "SUSE:Maintenance:Test:SLE-Module-Web-Scripting:12:"
+      },
+      "flavor" : "Server-DVD-Incidents",
+      "archs" : [
+         "x86_64",
+         "s390x",
+         "ppc64le",
+         "aarch64"
+      ]
+   }
 }

--- a/data/apimap.json
+++ b/data/apimap.json
@@ -1,0 +1,27 @@
+{
+    "SUSE:Updates:SLE-SERVER:12-SP2:"
+      : {
+        "archs" : [ "x86_64", "s390x", "ppc64le", "aarch64" ],
+        "version" : "12-SP2",
+        "flavor"  : "Server-DVD-Incidents",
+        "issues"
+        : {
+            "SDK_ISSUES"  : "SUSE:Updates:SLE-SDK:12-SP2:",
+            "HPCM_ISSUES" : "SUSE:Updates:SLE-Module-HPC:12:",
+            "WE_ISSUES"   : "SUSE:Updates:SLE-WE:12-SP2:"
+        }
+      },
+      "SUSE:Updates:SLE-SERVER:12-SP1-LTSS:"
+      : {
+        "archs" : [ "x86_64", "s390x", "ppc64le" ],
+        "version" : "12-SP1",
+        "flavor"  : "Server-DVD-Incidents"
+      },
+      "SUSE:Updates:SLE-DESKTOP:12-SP2:"
+      : {
+        "archs"   : ["x86_64"],
+        "version" : "12-SP2",
+        "flavor"  : "Desktop-DVD-Incidents",
+        "issues"  : { "SDK_ISSUES" : "SUSE:Updates:SLE-SDK:12-SP2:" }
+      }
+}

--- a/data/incidents.json
+++ b/data/incidents.json
@@ -1,188 +1,119 @@
 {
-  "SUSE:Updates:SLE-Live-Patching:12:x86_64": [
-    {
-      "ARCH": "x86_64", 
-      "DISTRI": "sle", 
-      "FLAVOR": "KGraft", 
-      "VERSION": "12"
-    }, 
-    {
-      "ARCH": "x86_64", 
-      "DISTRI": "sle", 
-      "FLAVOR": "Server-DVD-Incidents-Kernel",
-      "VERSION": "12",
-      "KGRAFT": "1"
-    }
-  ],
-  "SUSE:Updates:SLE-Live-Patching:12-SP3:x86_64": [
-    {
-      "ARCH": "x86_64",
-      "DISTRI": "sle", 
-      "FLAVOR": "Server-DVD-Incidents-Kernel", 
-      "VERSION": "12-SP3", 
-      "KGRAFT": "1" 
-    }
-  ],
-  "SUSE:Updates:SLE-SERVER:12-LTSS:ppc64le": [
-    {
-      "ARCH": "ppc64le", 
-      "DISTRI": "sle", 
-      "FLAVOR": "Server-DVD-Incidents", 
-      "VERSION": "12"
-    }
-  ], 
-  "SUSE:Updates:SLE-SERVER:12-LTSS:s390x": [
-    {
-      "ARCH": "s390x", 
-      "DISTRI": "sle", 
-      "FLAVOR": "Server-DVD-Incidents", 
-      "VERSION": "12"
-    }
-  ], 
-  "SUSE:Updates:SLE-SERVER:12-LTSS:x86_64": [
-    {
-      "ARCH": "x86_64", 
-      "DISTRI": "sle", 
-      "FLAVOR": "Server-DVD-Incidents", 
-      "VERSION": "12"
-    },
-    {
-      "ARCH": "x86_64", 
-      "DISTRI": "sle", 
-      "FLAVOR": "Server-DVD-Incidents-Kernel", 
-      "VERSION": "12"
-    }
-  ], 
-  "SUSE:Updates:SLE-SERVER:12-SP1-LTSS:ppc64le": [
-    {
-      "ARCH": "ppc64le", 
-      "DISTRI": "sle", 
-      "FLAVOR": "Server-DVD-Incidents", 
-      "VERSION": "12-SP1"
-    }
-  ], 
-  "SUSE:Updates:SLE-SERVER:12-SP1-LTSS:s390x": [
-    {
-      "ARCH": "s390x", 
-      "DISTRI": "sle", 
-      "FLAVOR": "Server-DVD-Incidents", 
-      "VERSION": "12-SP1"
-    }
-  ], 
-  "SUSE:Updates:SLE-SERVER:12-SP1-LTSS:x86_64": [
-    {
-      "ARCH": "x86_64", 
-      "DISTRI": "sle", 
-      "FLAVOR": "Server-DVD-Incidents", 
-      "VERSION": "12-SP1"
-    },
-    {
-      "ARCH": "x86_64", 
-      "DISTRI": "sle", 
-      "FLAVOR": "Server-DVD-Incidents-Kernel", 
-      "VERSION": "12-SP1"
-    }
-  ], 
-  "SUSE:Updates:SLE-SERVER:12-SP2:aarch64": [
-    {
-      "ARCH": "aarch64", 
-      "DISTRI": "sle", 
-      "FLAVOR": "Server-DVD-Incidents", 
-      "VERSION": "12-SP2"
-    }
-  ], 
-  "SUSE:Updates:SLE-SERVER:12-SP2:ppc64le": [
-    {
-      "ARCH": "ppc64le", 
-      "DISTRI": "sle", 
-      "FLAVOR": "Server-DVD-Incidents", 
-      "VERSION": "12-SP2"
-    }
-  ], 
-  "SUSE:Updates:SLE-SERVER:12-SP2:s390x": [
-    {
-      "ARCH": "s390x", 
-      "DISTRI": "sle", 
-      "FLAVOR": "Server-DVD-Incidents", 
-      "VERSION": "12-SP2"
-    }
-  ], 
-  "SUSE:Updates:SLE-DESKTOP:12-SP2:x86_64": [
-     {
-      "ARCH": "x86_64",
-      "DISTRI": "sle",
-      "FLAVOR": "Desktop-DVD-Incidents",
-      "VERSION": "12-SP2"
-    }
-  ],
-  "SUSE:Updates:SLE-SERVER:12-SP2:x86_64": [
-    {
-      "ARCH": "x86_64", 
-      "DISTRI": "sle", 
-      "FLAVOR": "Server-DVD-Incidents", 
-      "VERSION": "12-SP2"
-    },
-    {
-      "ARCH": "x86_64", 
-      "DISTRI": "sle", 
-      "FLAVOR": "Server-DVD-Incidents-Kernel", 
-      "VERSION": "12-SP2"
-    }
-  ], 
-  "SUSE:Updates:SLE-SERVER:12-SP3:aarch64": [
-    {
-      "ARCH": "aarch64", 
-      "DISTRI": "sle", 
-      "FLAVOR": "Server-DVD-Incidents", 
-      "VERSION": "12-SP3"
-    }
-  ], 
-  "SUSE:Updates:SLE-SERVER:12-SP3:ppc64le": [
-    {
-      "ARCH": "ppc64le", 
-      "DISTRI": "sle", 
-      "FLAVOR": "Server-DVD-Incidents", 
-      "VERSION": "12-SP3"
-    }
-  ], 
-  "SUSE:Updates:SLE-SERVER:12-SP3:s390x": [
-    {
-      "ARCH": "s390x", 
-      "DISTRI": "sle", 
-      "FLAVOR": "Server-DVD-Incidents", 
-      "VERSION": "12-SP3"
-    }
-  ], 
-  "SUSE:Updates:SLE-SERVER:12-SP3:x86_64": [
-    {
-      "ARCH": "x86_64", 
-      "DISTRI": "sle", 
-      "FLAVOR": "Server-DVD-Incidents", 
-      "VERSION": "12-SP3"
-    },
-    {
-      "ARCH": "x86_64", 
-      "DISTRI": "sle", 
-      "FLAVOR": "Server-DVD-Incidents-Kernel", 
-      "VERSION": "12-SP3"
-    }
-  ], 
-  "openSUSE:Leap:42.2:Update": [
-    {
-      "ARCH": "x86_64", 
-      "DISTRI": "opensuse", 
-      "FLAVOR": "Maintenance", 
-      "ISO": "openSUSE-Leap-42.2-DVD-x86_64.iso", 
-      "VERSION": "42.2"
-    }
-  ], 
-  "openSUSE:Leap:42.3:Update": [
-    {
-      "ARCH": "x86_64", 
-      "DISTRI": "opensuse", 
-      "FLAVOR": "Maintenance", 
-      "ISO": "openSUSE-Leap-42.3-DVD-x86_64.iso", 
-      "VERSION": "42.3"
-    }
-  ]
+   "SUSE:Updates:SLE-SERVER:12-LTSS:s390x" : {
+      "DISTRI" : "sle",
+      "ARCH" : "s390x",
+      "FLAVOR" : "Server-DVD-Incidents",
+      "VERSION" : "12"
+   },
+   "SUSE:Updates:SLE-SERVER:12-LTSS:ppc64le" : {
+      "DISTRI" : "sle",
+      "ARCH" : "ppc64le",
+      "FLAVOR" : "Server-DVD-Incidents",
+      "VERSION" : "12"
+   },
+   "SUSE:Updates:SLE-SERVER:12-SP1-LTSS:ppc64le" : {
+      "DISTRI" : "sle",
+      "ARCH" : "ppc64le",
+      "FLAVOR" : "Server-DVD-Incidents",
+      "VERSION" : "12-SP1"
+   },
+   "openSUSE:Leap:42.3:Update" : {
+      "FLAVOR" : "Maintenance",
+      "VERSION" : "42.3",
+      "DISTRI" : "opensuse",
+      "ARCH" : "x86_64",
+      "ISO" : "openSUSE-Leap-42.3-DVD-x86_64.iso"
+   },
+   "SUSE:Updates:SLE-DESKTOP:12-SP2:x86_64" : {
+      "FLAVOR" : "Desktop-DVD-Incidents",
+      "VERSION" : "12-SP2",
+      "DISTRI" : "sle",
+      "ARCH" : "x86_64"
+   },
+   "SUSE:Updates:SLE-SERVER:12-SP2:s390x" : {
+      "DISTRI" : "sle",
+      "ARCH" : "s390x",
+      "VERSION" : "12-SP2",
+      "FLAVOR" : "Server-DVD-Incidents"
+   },
+   "SUSE:Updates:SLE-SERVER:12-SP3:s390x" : {
+      "DISTRI" : "sle",
+      "ARCH" : "s390x",
+      "FLAVOR" : "Server-DVD-Incidents",
+      "VERSION" : "12-SP3"
+   },
+   "SUSE:Updates:SLE-Live-Patching:12-SP3:x86_64" : {
+      "DISTRI" : "sle",
+      "ARCH" : "x86_64",
+      "VERSION" : "12-SP3",
+      "FLAVOR" : "Server-DVD-Incidents-Kernel",
+      "KGRAFT" : "1"
+   },
+   "SUSE:Updates:SLE-SERVER:12-SP2:aarch64" : {
+      "DISTRI" : "sle",
+      "ARCH" : "aarch64",
+      "FLAVOR" : "Server-DVD-Incidents",
+      "VERSION" : "12-SP2"
+   },
+   "SUSE:Updates:SLE-SERVER:12-SP3:x86_64" : {
+      "VERSION" : "12-SP3",
+      "FLAVOR" : "Server-DVD-Incidents",
+      "DISTRI" : "sle",
+      "ARCH" : "x86_64"
+   },
+   "SUSE:Updates:SLE-SERVER:12-SP3:ppc64le" : {
+      "VERSION" : "12-SP3",
+      "FLAVOR" : "Server-DVD-Incidents",
+      "ARCH" : "ppc64le",
+      "DISTRI" : "sle"
+   },
+   "SUSE:Updates:SLE-Live-Patching:12:x86_64" : {
+      "FLAVOR" : "KGraft",
+      "VERSION" : "12",
+      "ARCH" : "x86_64",
+      "DISTRI" : "sle"
+   },
+   "SUSE:Updates:SLE-SERVER:12-SP3:aarch64" : {
+      "VERSION" : "12-SP3",
+      "FLAVOR" : "Server-DVD-Incidents",
+      "DISTRI" : "sle",
+      "ARCH" : "aarch64"
+   },
+   "SUSE:Updates:SLE-SERVER:12-SP1-LTSS:x86_64" : {
+      "VERSION" : "12-SP1",
+      "FLAVOR" : "Server-DVD-Incidents",
+      "DISTRI" : "sle",
+      "ARCH" : "x86_64"
+   },
+   "SUSE:Updates:SLE-SERVER:12-SP2:ppc64le" : {
+      "VERSION" : "12-SP2",
+      "FLAVOR" : "Server-DVD-Incidents",
+      "ARCH" : "ppc64le",
+      "DISTRI" : "sle"
+   },
+   "SUSE:Updates:SLE-SERVER:12-SP1-LTSS:s390x" : {
+      "ARCH" : "s390x",
+      "DISTRI" : "sle",
+      "VERSION" : "12-SP1",
+      "FLAVOR" : "Server-DVD-Incidents"
+   },
+   "SUSE:Updates:SLE-SERVER:12-LTSS:x86_64" : {
+      "FLAVOR" : "Server-DVD-Incidents",
+      "VERSION" : "12",
+      "DISTRI" : "sle",
+      "ARCH" : "x86_64"
+   },
+   "openSUSE:Leap:42.2:Update" : {
+      "DISTRI" : "opensuse",
+      "ARCH" : "x86_64",
+      "ISO" : "openSUSE-Leap-42.2-DVD-x86_64.iso",
+      "FLAVOR" : "Maintenance",
+      "VERSION" : "42.2"
+   },
+   "SUSE:Updates:SLE-SERVER:12-SP2:x86_64" : {
+      "VERSION" : "12-SP2",
+      "FLAVOR" : "Server-DVD-Incidents",
+      "ARCH" : "x86_64",
+      "DISTRI" : "sle"
+   }
 }

--- a/data/incidents.json
+++ b/data/incidents.json
@@ -107,6 +107,14 @@
       "VERSION": "12-SP2"
     }
   ], 
+  "SUSE:Updates:SLE-DESKTOP:12-SP2:x86_64": [
+     {
+      "ARCH": "x86_64",
+      "DISTRI": "sle",
+      "FLAVOR": "Desktop-DVD-Incidents",
+      "VERSION": "12-SP2"
+    }
+  ],
   "SUSE:Updates:SLE-SERVER:12-SP2:x86_64": [
     {
       "ARCH": "x86_64", 

--- a/data/incidents.json
+++ b/data/incidents.json
@@ -30,6 +30,12 @@
       "DISTRI" : "sle",
       "ARCH" : "x86_64"
    },
+   "SUSE:Updates:SLE-DESKTOP:12-SP3:x86_64" : {
+      "FLAVOR" : "Desktop-DVD-Incidents",
+      "VERSION" : "12-SP3",
+      "DISTRI" : "sle",
+      "ARCH" : "x86_64"
+   },
    "SUSE:Updates:SLE-SERVER:12-SP2:s390x" : {
       "DISTRI" : "sle",
       "ARCH" : "s390x",

--- a/openqa-maintenance.py
+++ b/openqa-maintenance.py
@@ -910,6 +910,7 @@ class OpenQABot(ReviewBot.ReviewBot):
         incident_project = str(job['project'])
         comment_info = self.find_obs_request_comment(project_name=incident_project)
         comment_id = comment_info.get('id', None)
+        comment_build = str(comment_info.get('revision', ''))
 
         openqa_posts = []
         for prod in API_MAP.keys():
@@ -918,12 +919,12 @@ class OpenQABot(ReviewBot.ReviewBot):
         for s in openqa_posts:
             jobs = self.incident_openqa_jobs(s)
             # take the project comment as marker for not posting jobs
-            if not len(jobs) and comment_info.get('revision', '') != job['openqa_build']:
+            if not len(jobs) and comment_build != str(job['openqa_build']):
                 if self.dryrun:
                     print 'WOULD POST', json.dumps(s, sort_keys=True)
                 else:
                     ret = self.openqa.openqa_request('POST', 'isos', data=s, retries=1)
-                openqa_jobs += self.incident_openqa_jobs(s)
+                    openqa_jobs += self.incident_openqa_jobs(s)
             else:
                 print s, 'got', len(jobs)
                 openqa_jobs += jobs

--- a/openqa-maintenance.py
+++ b/openqa-maintenance.py
@@ -879,7 +879,7 @@ class OpenQABot(ReviewBot.ReviewBot):
 
     def test(self):
         for inc in requests.get('https://maintenance.suse.de/api/incident/active/').json():
-            if not inc in ['4871', '5146', '2129', '5219']: continue
+            if not inc in ['a4871', 'a5146', 'a2129', 'a5219', '5230']: continue
             job = requests.get('https://maintenance.suse.de/api/incident/' + inc).json()
             if job['meta']['state'] in ['final', 'gone']:
                 continue

--- a/openqa-maintenance.py
+++ b/openqa-maintenance.py
@@ -858,7 +858,7 @@ class OpenQABot(ReviewBot.ReviewBot):
             need = False
             settings = {'FLAVOR': pmap['flavor'], 'VERSION': pmap['version'], 'ARCH': arch, 'DISTRI': 'sle'}
             issues = pmap.get('issues', {})
-            issues['OS_ISSUES'] = product_prefix
+            issues['OS_TEST_ISSUES'] = product_prefix
             for key, prefix in issues.items():
                 if prefix + arch in job['channels']:
                     settings[key] = str(job['id'])
@@ -879,7 +879,10 @@ class OpenQABot(ReviewBot.ReviewBot):
 
     def test(self):
         for inc in requests.get('https://maintenance.suse.de/api/incident/active/').json():
-            if not inc in ['a4871', 'a5146', 'a2129', 'a5219', '5230']: continue
+            if not inc in ['a4871', 'a5146', 'a2129', '5219', '5217', '5230']: continue
+            #if not inc.startswith('52'): continue
+            print inc
+            #continue
             job = requests.get('https://maintenance.suse.de/api/incident/' + inc).json()
             if job['meta']['state'] in ['final', 'gone']:
                 continue
@@ -910,7 +913,7 @@ class OpenQABot(ReviewBot.ReviewBot):
                 else:
                     print s, 'got', len(jobs)
                     openqa_jobs += jobs
-            if not openqa_done:
+            if not openqa_done or len(openqa_jobs) == 0:
                 continue
             #print openqa_jobs
             msg = self.summarize_openqa_jobs(openqa_jobs)

--- a/openqa-maintenance.py
+++ b/openqa-maintenance.py
@@ -436,9 +436,8 @@ class OpenQABot(ReviewBot.ReviewBot):
             self.check_suse_incidents()
 
         # first calculate the latest build number for current jobs
-        self.gather_test_builds()
-
         self.pending_target_repos = set()
+        self.gather_test_builds()
 
         started = []
         # then check progress on running incidents
@@ -897,8 +896,7 @@ class OpenQABot(ReviewBot.ReviewBot):
 
     def check_suse_incidents(self):
         for inc in requests.get('https://maintenance.suse.de/api/incident/active/').json():
-            if not inc in ['5232']:
-                continue
+            # if not inc in ['5232']: continue
             # if not inc.startswith('52'): continue
             print inc
             # continue

--- a/openqa-maintenance.py
+++ b/openqa-maintenance.py
@@ -879,7 +879,7 @@ class OpenQABot(ReviewBot.ReviewBot):
 
     def test(self):
         for inc in requests.get('https://maintenance.suse.de/api/incident/active/').json():
-            if not inc in ['4871', '5146', '2129']: continue
+            if not inc in ['4871', '5146', '2129', '5219']: continue
             job = requests.get('https://maintenance.suse.de/api/incident/' + inc).json()
             if job['meta']['state'] in ['final', 'gone']:
                 continue


### PR DESCRIPTION
I'm working on this for a week and more - it's no longer looking at requests, but at incident projects and test updates and then only aggregates into the request if it opened.

This way the release managers get to know about problems in incident *before* they open the request into testing.

But I didn't find a good way to make this work for opensuse too - and the kgraft testing needs work too.