### PR TITLE
check_source: add devel review for delete request using MaintenanceChecker logic.

### DIFF
--- a/check_maintenance_incidents.py
+++ b/check_maintenance_incidents.py
@@ -151,6 +151,11 @@ class MaintenanceChecker(ReviewBot.ReviewBot):
 
         return True
 
+    def check_action_delete(self, req, a):
+        self._check_maintainer_review_needed(req, a)
+
+        return True
+
 
     def check_one_request(self, req):
         self.add_factory_source = False

--- a/check_source.py
+++ b/check_source.py
@@ -13,6 +13,7 @@ except ImportError:
 import osc.core
 import urllib2
 import ReviewBot
+from check_maintenance_incidents import MaintenanceChecker
 
 class CheckSource(ReviewBot.ReviewBot):
 
@@ -23,6 +24,8 @@ class CheckSource(ReviewBot.ReviewBot):
 
         # ReviewBot options.
         self.only_one_action = True
+
+        self.maintbot = MaintenanceChecker(*args, **kwargs)
 
         self.ignore_devel = False
         self.review_team = 'opensuse-review-team'
@@ -220,6 +223,9 @@ class CheckSource(ReviewBot.ReviewBot):
         # Decline the delete request against linked package.
         links = root.findall('sourceinfo/linked')
         if links is None or len(links) == 0:
+            # Utilize maintbot to add devel project review if necessary.
+            self.maintbot.check_one_request(request)
+
             if not self.skip_add_reviews and self.repo_checker is not None:
                 self.add_review(self.request, by_user=self.repo_checker, msg='Is this delete request safe?')
             return True


### PR DESCRIPTION
Since the new repo_checker does not require maintainer submission `check_source` will now add the review in-line with other responsibilities. This is the same style as `leaper.py` although the code-base could likely use a bit or re-organization.

For example:

```
./check_source.py --osc-debug --debug --dry --group factory-auto --review-team=None id 511969
GET https://api.opensuse.org/request/511969?withfullhistory=1
INFO:check_source.py:checking 511969
GET https://api.opensuse.org/source/openSUSE:Factory?view=info&package=python3-twine&nofilename=1
GET https://api.opensuse.org/search/owner?project=openSUSE%3AFactory&binary=python3-twine
DEBUG:check_source.py:author: sebix, maintainers: aledr,TheBlackCat,matejcik,sleep_walker,apersaud,posophe => need review
INFO:check_source.py:POST https://api.opensuse.org/request/511969?cmd=addreview&by_project=devel%3Alanguages%3Apython3
INFO:check_source.py:POST https://api.opensuse.org/request/511969?cmd=addreview&by_user=factory-repo-checker
GET https://api.opensuse.org/request/511969
INFO:check_source.py:511969 accepted: ok
DEBUG:check_source.py:511969 review not changed
```

Would add `devel:languages:python3` review since the submitter is not maintainer. May also require manually acceptance in Factory. I would imagine this is not the first time this occurs. In such cases do you just manually accept `factory-repo-checker` review? Presumably that should not be necessary using this workflow since the review will be acceptable directly.

Another review for a package that actually has direct maintainers:

```
./check_source.py --osc-debug --debug --dry --group factory-auto --review-team=None id 505645
GET https://api.opensuse.org/request/505645?withfullhistory=1
INFO:check_source.py:checking 505645
GET https://api.opensuse.org/source/openSUSE:Factory?view=info&package=libdb-4_5&nofilename=1
GET https://api.opensuse.org/search/owner?project=openSUSE%3AFactory&binary=libdb-4_5
DEBUG:check_source.py:author: scarabeus_iv, maintainers: rhafer,rmax => need review
INFO:check_source.py:POST https://api.opensuse.org/request/505645?by_package=libdb-4_5&cmd=addreview&by_project=devel%3Alibraries%3Ac_c%2B%2B
INFO:check_source.py:POST https://api.opensuse.org/request/505645?cmd=addreview&by_user=factory-repo-checker
GET https://api.opensuse.org/request/505645
INFO:check_source.py:505645 accepted: ok
DEBUG:check_source.py:505645 review not changed
```

The review is correctly added.

Lastly a request that was submitted by the maintainer:

```
./check_source.py --osc-debug --debug --dry --group factory-auto --review-team=None id 501634
GET https://api.opensuse.org/request/501634?withfullhistory=1
INFO:check_source.py:checking 501634
GET https://api.opensuse.org/source/openSUSE:Factory?view=info&package=kiwi&nofilename=1
GET https://api.opensuse.org/search/owner?project=openSUSE%3AFactory&binary=kiwi
DEBUG:check_source.py:sax2 is maintainer
INFO:check_source.py:POST https://api.opensuse.org/request/501634?cmd=addreview&by_user=factory-repo-checker
GET https://api.opensuse.org/request/501634
INFO:check_source.py:501634 accepted: ok
DEBUG:check_source.py:501634 review not changed
```

Again that output looks correct as no review is added.

It seems delete requests are very commonly submitted by non-maintainers so I am a bit curious why this has not come up as more of an issue before. The discussion in #983 led me to believe this is very rare if ever.

Alternative approach in #1013 closed.
Fixes #983.