### PR TITLE
repo_checker: provide project_only subcommand to write result to dashboard/repo_checker.

### DIFF
--- a/devel-project.py
+++ b/devel-project.py
@@ -47,9 +47,7 @@ osc.core.search = search
 
 def staging_api(args):
     Config(args.project)
-    api = StagingAPI(osc.conf.config['apiurl'], args.project)
-    staging = '%s:Staging' % api.project
-    return (api, staging)
+    return StagingAPI(osc.conf.config['apiurl'], args.project)
 
 def devel_projects_get(apiurl, project):
     """
@@ -78,13 +76,12 @@ def list(args):
         print(out)
 
         if args.write:
-            api, staging = staging_api(args)
-            if api.load_file_content(staging, 'dashboard', 'devel_projects') != out:
-                api.save_file_content(staging, 'dashboard', 'devel_projects', out)
+            api = staging_api(args)
+            api.dashboard_content_ensure('devel_projects', out, 'devel_projects write')
 
 def devel_projects_load(args):
-    api, staging = staging_api(args)
-    devel_projects = api.load_file_content(staging, 'dashboard', 'devel_projects')
+    api = staging_api(args)
+    devel_projects = api.dashboard_content_load('devel_projects')
 
     if devel_projects:
         return devel_projects.splitlines()

--- a/osc-staging.py
+++ b/osc-staging.py
@@ -410,7 +410,7 @@ def do_staging(self, subcmd, opts, *args):
             # Is it safe to accept? Meaning: /totest contains what it should and is not dirty
             version_totest = api.get_binary_version(api.project, "openSUSE-release.rpm", repository="totest", arch="x86_64")
             if version_totest:
-                version_openqa = api.load_file_content("%s:Staging" % api.project, "dashboard", "version_totest")
+                version_openqa = api.dashboard_content_load('version_totest')
                 totest_dirty = api.is_repo_dirty(api.project, 'totest')
                 print("version_openqa: %s / version_totest: %s / totest_dirty: %s\n" % (version_openqa, version_totest, totest_dirty))
             else:
@@ -424,7 +424,7 @@ def do_staging(self, subcmd, opts, *args):
                 version_openqa = version_totest
                 totest_dirty   = False
             else:
-                version_openqa = api.load_file_content("%s:Staging" % api.project, "dashboard", "version_totest")
+                version_openqa = api.dashboard_content_load('version_totest')
                 totest_dirty   = api.is_repo_dirty(api.project, 'totest')
 
             if version_openqa == version_totest and not totest_dirty:

--- a/osclib/conf.py
+++ b/osclib/conf.py
@@ -152,7 +152,7 @@ class Config(object):
         if not conf.config[self.project].get('remote-config', True):
             return
 
-        config = api.load_file_content(api.cstaging, 'dashboard', 'config')
+        config = api.dashboard_content_load('config')
         if config:
             cp = ConfigParser()
             config = '[remote]\n' + config
@@ -161,4 +161,4 @@ class Config(object):
             self.populate_conf()
         elif config is None:
             # Write empty config to allow for caching.
-            api.save_file_content(api.cstaging, 'dashboard', 'config', '')
+            api.dashboard_content_save('config', '')

--- a/osclib/stagingapi.py
+++ b/osclib/stagingapi.py
@@ -593,14 +593,14 @@ class StagingAPI(object):
 
     @memoize(session=True)
     def get_ignored_requests(self):
-        ignore = self.load_file_content('{}:Staging'.format(self.project), 'dashboard', 'ignored_requests')
+        ignore = self.dashboard_content_load('ignored_requests')
         if ignore is None or not ignore:
             return {}
         return yaml.safe_load(ignore)
 
     def set_ignored_requests(self, ignore_requests):
         ignore = yaml.dump(ignore_requests, default_flow_style=False)
-        self.save_file_content('{}:Staging'.format(self.project), 'dashboard', 'ignored_requests', ignore)
+        self.dashboard_content_ensure('ignored_requests', ignore)
 
     @memoize(session=True, add_invalidate=True)
     def get_open_requests(self, query_extra=None):
@@ -1411,6 +1411,16 @@ class StagingAPI(object):
         """
         url = self.makeurl(['source', project, package, filename], {'comment': comment})
         http_PUT(url, data=content)
+
+    def dashboard_content_load(self, filename):
+        return self.load_file_content(self.cstaging, 'dashboard', filename)
+
+    def dashboard_content_save(self, filename, content, comment='script updated'):
+        return self.save_file_content(self.cstaging, 'dashboard', filename, content, comment)
+
+    def dashboard_content_ensure(self, filename, content, comment='script updated'):
+        if content != self.dashboard_content_load(filename):
+            self.dashboard_content_save(filename, content, comment)
 
     def update_status_or_deactivate(self, project, command):
         meta = self.get_prj_pseudometa(project)

--- a/repo-checker.pl
+++ b/repo-checker.pl
@@ -68,14 +68,18 @@ sub write_package($$) {
     return $name;
 }
 
-my @rpms  = glob("$repodir/*.rpm");
+my @rpms;
 my $tmpdir = tempdir( "repochecker-XXXXXXX", TMPDIR => 1, CLEANUP => 1 );
 my $pfile = $tmpdir . "/packages";
 open( PACKAGES, ">", $pfile ) || die 'can not open';
 print PACKAGES "=Ver: 2.0\n";
 
-foreach my $package (@rpms) {
-    write_package( 1, $package );
+# Allow $repodir to be empty indicating only to review $dir.
+if (length($repodir)) {
+    my @rpms = glob("$repodir/*.rpm");
+    foreach my $package (@rpms) {
+        write_package(1, $package);
+    }
 }
 
 @rpms = glob("$dir/*.rpm");

--- a/suppkg_rebuild.py
+++ b/suppkg_rebuild.py
@@ -112,7 +112,7 @@ class StagingHelper(object):
 
     def crawl(self):
         """Main method"""
-        rebuild_data = self.api.load_file_content(self.project + ':Staging', 'dashboard', 'support_pkg_rebuild')
+        rebuild_data = self.api.dashboard_content_load('support_pkg_rebuild')
         if rebuild_data is None:
             print "There is no support_pkg_rebuild file!"
             return
@@ -173,7 +173,7 @@ class StagingHelper(object):
         rebuild_data_updated = ET.tostring(root)
         logging.debug(rebuild_data_updated)
         if rebuild_data_updated != rebuild_data:
-            self.api.save_file_content(self.project + ':Staging', 'dashboard',
+            self.api.dashboard_content_save(
                 'support_pkg_rebuild', rebuild_data_updated, 'support package rebuild')
 
 def main(args):

--- a/tests/config_tests.py
+++ b/tests/config_tests.py
@@ -27,7 +27,7 @@ class TestConfig(unittest.TestCase):
         self.assertEqual('remote-indeed', conf.config[PROJECT]['remote-only'])
 
     def test_remote_none(self):
-        self.api.save_file_content(self.api.cstaging, 'dashboard', 'config', '')
+        self.api.dashboard_content_save('config', '')
         self.assertEqual(self.obs.dashboard_counts['config'], 1)
         self.config.apply_remote(self.api)
         # Ensure blank file not overridden.

--- a/totest-manager.py
+++ b/totest-manager.py
@@ -453,8 +453,7 @@ class ToTestBase(object):
         new_snapshot = self.current_version()
 
         current_result = self.overall_result(current_snapshot)
-        current_qa_version = self.api.load_file_content(
-            "%s:Staging" % self.api.project, "dashboard", "version_totest")
+        current_qa_version = self.api.dashboard_content_load('version_totest')
 
         logger.info('current_snapshot %s: %s' %
                     (current_snapshot, self._result2str(current_result)))


### PR DESCRIPTION
- 491a42ee858d3948c98878b5de72b4d177464a61:
    **repo_checker: provide project_only subcommand to write result to installcheck.**

- 8f0aba6d6227a7372663a4a9b0aef91fb129f6c7:
    repo_checker.pl: allow empty $repodir allowing just a project-wide check.

- 797c92f26b2702acacb1b49c7fe71f7189351851:
    stagingapi: provide dashboard_content_{load,save,ensure}() and utilize.

Finally decided to add dashboard_content specific methods since the same pattern is all over. Makes for a bit cleaner usage.

This is still relevant since the `repo_checker` will only actively check requests and ring packages. This check should run once a day against the whole project to see if anything introduced due to interesting build interactions or packages staged separately.

The existing bash script will be replaced by `./repo_checker.pl project_only openSUSE:Factory` which will handle writing to the dashboard. The previous script only ran the `installcheck` against the whole project which means fileconflicts were never included. I modified `repo_checker.pl` so that it can be used for this purpose which means the same check script is run against both requests and the whole project rather than two different paths.

I believe it makes sense to enhance this in the following ways:

- wait for a full build to complete (previous script did not so this is more than equal feature set)
- parse output and post comments on effected packages

I will create issues to track each.

Fixes #981.