### PR TITLE
repo_checker: add whitelist for adoption phase.

### DIFF
--- a/osclib/cycle.py
+++ b/osclib/cycle.py
@@ -155,7 +155,7 @@ class CycleDetector(object):
         root = None
         try:
             # print('Generating _builddepinfo for (%s, %s, %s)' % (project, repository, arch))
-            url = makeurl(self.api.apiurl, ['/build/%s/%s/%s/_builddepinfo' % (project, repository, arch)])
+            url = makeurl(self.api.apiurl, ['build/%s/%s/%s/_builddepinfo' % (project, repository, arch)])
             root = http_GET(url).read()
         except urllib2.HTTPError, e:
             print('ERROR in URL %s [%s]' % (url, e))

--- a/repo_checker.pl
+++ b/repo_checker.pl
@@ -21,6 +21,7 @@ my $arch = shift @ARGV;
 my $dir = shift @ARGV;
 my %toignore;
 my $repodir;
+my %whitelist;
 while (@ARGV) {
     my $switch = shift @ARGV;
     if ( $switch eq "-f" ) {
@@ -34,6 +35,9 @@ while (@ARGV) {
     }
     elsif ( $switch eq "-r" ) {
         $repodir = shift @ARGV;
+    }
+    elsif ( $switch eq "-w" ) {
+        %whitelist = map { $_ => 1 } split(/\,/, shift @ARGV);
     }
     else {
         print "read the source luke: $switch ? \n";
@@ -84,7 +88,9 @@ if (length($repodir)) {
 @rpms = glob("$dir/*.rpm");
 foreach my $package (@rpms) {
     my $name = write_package( 0, $package );
-    $targets{$name} = 1;
+    if (!exists($whitelist{$name})) {
+        $targets{$name} = 1;
+    }
 }
 
 close(PACKAGES);

--- a/repo_checker.py
+++ b/repo_checker.py
@@ -290,7 +290,7 @@ class RepoChecker(ReviewBot.ReviewBot):
             comment.append('### new [cycle(s)](/project/repository_state/{}/standard)\n'.format(group))
             comment.append(results['cycle'].comment + '\n')
         if not results['install'].success:
-            comment.append('### [install check](/package/view_file/{}:Staging/dashboard/installcheck?expand=1)\n'.format(project))
+            comment.append('### [install check & file conflicts](/package/view_file/{}:Staging/dashboard/repo_checker)\n'.format(project))
             comment.append(results['install'].comment + '\n')
 
     def check_action_submit(self, request, action):


### PR DESCRIPTION
- e526c964c989cf97c1f9ad6e24ef306b7c02ecc2:
    osclib/cycle: remove extra leading slash.

- f56cb54d9046dc51464105dd3ecb2b336328a1ed:
    repo_checker: add whitelist for adoption phase.
    
    Given all the pent up issues hidden by the previous checker this is sadly necessary.

Workaround for #1012 during adoption phase.