### PR TITLE
repo_checker: provide --post-comments option on project_only subcommand (and cleanups).

### DIFF
--- a/ReviewBot.py
+++ b/ReviewBot.py
@@ -446,15 +446,16 @@ class ReviewBot(object):
 
         comments = self.comment_api.get_comments(**kwargs)
         comment, _ = self.comment_api.comment_find(comments, self.bot_name, info)
+        debug_key = '/'.join(kwargs.values())
         if (comment is not None and
             ((identical and comment['comment'] == message) or
              (not identical and comment['comment'].count('\n') == message.count('\n')))
         ):
             # Assume same state/result and number of lines in message is duplicate.
-            self.logger.debug('previous comment too similar to bother commenting again')
+            self.logger.debug('previous comment on {} too similar'.format(debug_key))
             return
 
-        self.logger.debug('adding comment to {}: {}'.format('/'.join(kwargs.values()), message))
+        self.logger.debug('adding comment to {}: {}'.format(debug_key, message))
 
         if not self.dryrun:
             if comment is None:

--- a/ReviewBot.py
+++ b/ReviewBot.py
@@ -426,11 +426,13 @@ class ReviewBot(object):
     def comment_handler_lines_deduplicate(self):
         self.comment_handler.lines = list(OrderedDict.fromkeys(self.comment_handler.lines))
 
-    def comment_write(self, state='done', result=None, project=None, request=None,
-                      message=None, identical=False):
+    def comment_write(self, state='done', result=None, project=None, package=None,
+                      request=None, message=None, identical=False):
         """Write comment from log messages if not similar to previous comment."""
         if project:
             kwargs = {'project_name': project}
+            if package:
+                kwargs['package_name'] = package
         else:
             if request is None:
                 request = self.request
@@ -452,7 +454,7 @@ class ReviewBot(object):
             self.logger.debug('previous comment too similar to bother commenting again')
             return
 
-        self.logger.debug('adding comment to {}: {}'.format(kwargs.itervalues().next(), message))
+        self.logger.debug('adding comment to {}: {}'.format('/'.join(kwargs.values()), message))
 
         if not self.dryrun:
             if comment is None:

--- a/osclib/core.py
+++ b/osclib/core.py
@@ -12,6 +12,8 @@ from osc.core import owner
 from osc.core import show_project_meta
 from osclib.memoize import memoize
 
+BINARY_REGEX = r'(?:.*::)?(?P<filename>(?P<name>.*?)-(?P<version>[^-]+)-(?P<release>[^-]+)\.(?P<arch>[^-\.]+))'
+RPM_REGEX = BINARY_REGEX + '\.rpm'
 BinaryParsed = namedtuple('BinaryParsed', ('filename', 'name', 'arch'))
 
 
@@ -91,18 +93,18 @@ def request_staged(request):
 def binary_list(apiurl, project, repository, arch, package=None):
     parsed = []
     for binary in get_binarylist(apiurl, project, repository, arch, package):
-        result = re.match(r'(.*)-([^-]*)-([^-]*)\.([^-\.]+)\.rpm', binary)
+        result = re.match(RPM_REGEX, binary)
         if not result:
             continue
 
-        name = result.group(1)
+        name = result.group('name')
         if name.endswith('-debuginfo') or name.endswith('-debuginfo-32bit'):
             continue
         if name.endswith('-debugsource'):
             continue
-        if result.group(4) == 'src':
+        if result.group('arch') == 'src':
             continue
 
-        parsed.append(BinaryParsed(binary, name, result.group(4)))
+        parsed.append(BinaryParsed(result.group('filename'), name, result.group('arch')))
 
     return parsed

--- a/osclib/core.py
+++ b/osclib/core.py
@@ -14,7 +14,7 @@ from osclib.memoize import memoize
 
 BINARY_REGEX = r'(?:.*::)?(?P<filename>(?P<name>.*?)-(?P<version>[^-]+)-(?P<release>[^-]+)\.(?P<arch>[^-\.]+))'
 RPM_REGEX = BINARY_REGEX + '\.rpm'
-BinaryParsed = namedtuple('BinaryParsed', ('filename', 'name', 'arch'))
+BinaryParsed = namedtuple('BinaryParsed', ('package', 'filename', 'name', 'arch'))
 
 
 @memoize(session=True)
@@ -105,6 +105,6 @@ def binary_list(apiurl, project, repository, arch, package=None):
         if result.group('arch') == 'src':
             continue
 
-        parsed.append(BinaryParsed(result.group('filename'), name, result.group('arch')))
+        parsed.append(BinaryParsed(package, result.group('filename'), name, result.group('arch')))
 
     return parsed

--- a/repo_checker.py
+++ b/repo_checker.py
@@ -202,11 +202,10 @@ class RepoChecker(ReviewBot.ReviewBot):
         return ignore
 
     def package_whitelist(self, project, arch):
-        product = project.split(':Staging:', 1)[0]
         prefix = 'repo_checker-package-whitelist'
         whitelist = set()
         for key in [prefix, '-'.join([prefix, arch])]:
-            whitelist.update(self.staging_config[product].get(key, '').split(' '))
+            whitelist.update(self.staging_config[project].get(key, '').split(' '))
         return whitelist
 
     def install_check(self, directory_project, directory_group, arch, ignore, whitelist):

--- a/repo_checker.py
+++ b/repo_checker.py
@@ -66,6 +66,9 @@ class RepoChecker(ReviewBot.ReviewBot):
             # Sort sections by text to group binaries together.
             sections = sorted(sections, key=lambda s: s.text)
             message = '\n'.join([section.text for section in sections])
+            if len(message) > 16384:
+                # Truncate messages to avoid crashing OBS.
+                message = message[:16384 - 3] + '...'
             message = '```\n' + message.strip() + '\n```'
             message = 'The version of this package in `{}` has installation issues and may not be installable:\n\n'.format(project) + message
 


### PR DESCRIPTION
- f42cc4bcc9f599b1059127e7ce310fe926e3eef6:                                                                                                
    repo_checker: truncate long messages to avoid crashing OBS.                                                                            
                                                                                                                                           
- 722764a1f528e0cb9bd1cc9a29086c7f04656c32:
    **repo_checker: provide --post-comments option on project_only subcommand.**

- ce35a686ddafa6dd8943ef808fa5e7ee1e0c4f93:
    repo_checker: provide optional parsing of install check output and mapping to package.

- d87ee4c38ea59ed86f87774113b9d5bcf060374f:
    repo_checker: package_whitelist() does not need to support group splitting to find product.

- 924db6024b3587a177ce860a27b9d5d46886d9f0:
    osclib/core: provide package_binary_list() to efficiently obtain binary to package map.

- 0452fb266bcf1548b63f53535120062234419992:
    osclib/core: add package to BinaryParsed tuple.

- 16c5c92bcc2eddb29add606e930255f79659206c:
    osclib/core: provide BINARY_REGEX named group pattern and utilize.

- cfbd479ed74db16906d66de26f4bf2a151870cc8:
    ReviewBot: comment_write(): support package.

Deployment as service should be blocked by #1029 even though old `repo_checker` dumped to file regardless this is noisy and makes false positives more annoying.

Invocation is simple:

```
./repo_checker.py --verbose project_only --post-comments openSUSE:Factory
```

I went ahead and did a manual run in order to get the cleanup started especially with SLE/Leap 15 branching from Factory. The script produced `111` comments on devel packages containing the aggregated problems.

To be clear this approach:

- parses the `installcheck` & `file conflict` output
- maps the binary names back to packages
- groups all messages related to the same package
- sorts the output and posts as comment on package in devel project in order to trigger notifications

I debated posting bugs to bugzilla, but that would be a fair bit more work especially considering the clean comments api we have for avoiding useless updates, but ensuring a single comment. I did envision shared bugs between two packages that have file conflicts which would be neat, but this just duplicates those messages to both packages.

A hash representing the binaries and number of issues is generated to avoid updating comment for version updates or release increments while still properly picking up new or changes to existing issues.

Depending on how this works out and opinions this approach can be broadened for the rest of repo_checker or at minimum include for duplicate binary checks.

After the recent fixes that were hiding all `-32bit` imported binaries in the `x86_64` space added to the already exposed issues there are quite a few even after all my fixes.

See [dashboard/repo_checker](https://build.opensuse.org/package/view_file/openSUSE:Factory:Staging/dashboard/repo_checker) for an updated report.

The end result are package comments like the following on [devel:languages:ruby:extensions/rubygem-celluloid](https://build.opensuse.org/package/show/devel:languages:ruby:extensions/rubygem-celluloid).

![image](https://user-images.githubusercontent.com/22943929/28904145-83aae4d6-77ce-11e7-82ec-856f8167a4d8.png)

One caveat being that there is no simple way of removing these comments since the OBS comment API does not provide a way of querying all comments by a user so each devel project would have to be scanned. Alternatively, on accept comments for all effected packages could be removed. I would expect these comments to be relatively rare once the new `repo_checker` is enforcing cleanliness on new requests so this is more of a stop-gap for getting maintainers to act for the initial cleanup. It seems simple enough for maintainers to remove them once fixes are accepted.

Fixes #1030.