### PR TITLE
suppkg_rebuild: Clean up supportpkg list also

### DIFF
--- a/osclib/accept_command.py
+++ b/osclib/accept_command.py
@@ -41,10 +41,12 @@ class AcceptCommand(object):
         tree = ET.parse(data)
         root = tree.getroot()
         for stg in root.findall('staging'):
-	    if stg.get('name') == project:
+            if stg.get('name') == project:
                 stg.find('rebuild').text = 'unknown'
+                stg.find('supportpkg').text = ''
 
-        # reset accpted staging project rebuild state to unknown
+        # reset accpted staging project rebuild state to unknown and clean up
+        # supportpkg list
         url = self.api.makeurl(['source', self.api.cstaging, 'dashboard', 'support_pkg_rebuild'])
         content = ET.tostring(root)
         http_PUT(url + '?comment=accept+command+update', data=content)


### PR DESCRIPTION
Have to clean up supportpkg list also during accepting staging project, otherwise suppkg_rebuild can not handle it correct in case next time staged package in the same staging project had the same supportpkg list.