### PR TITLE
core.owner_fallback(): check if startswith() instead of equal.

### DIFF
--- a/osclib/core.py
+++ b/osclib/core.py
@@ -21,7 +21,7 @@ BinaryParsed = namedtuple('BinaryParsed', ('package', 'filename', 'name', 'arch'
 def owner_fallback(apiurl, project, package):
     root = owner(apiurl, package, project=project)
     entry = root.find('owner')
-    if not entry or entry.get('project') == project:
+    if not entry or project.startswith(entry.get('project')):
         # Fallback to global (ex Factory) maintainer.
         root = owner(apiurl, package)
     return root


### PR DESCRIPTION
This allows for cases where the requested project was something like openSUSE:Leap:42.3:Update and the returned project was openSUSE:Leap:42.3. With this change the fallback will be triggered and the global maintainer will then be used.

Worth considering if this will negatively effect `leaper` or `check_source`.

Fixes #1068.