### PR TITLE
ReviewBot: get_devel_project(): correct error handling to only allow 404.

### DIFF
--- a/ReviewBot.py
+++ b/ReviewBot.py
@@ -208,7 +208,6 @@ class ReviewBot(object):
             raise osc.oscerr.WrongArgs("missing by_*")
 
         for r in req.reviews:
-            print(r.by_group, r.by_project, r.by_package, r.by_user, r.state)
             if (r.by_group == by_group and
                 r.by_project == by_project and
                 r.by_package == by_package and

--- a/ReviewBot.py
+++ b/ReviewBot.py
@@ -369,8 +369,8 @@ class ReviewBot(object):
             if node is not None:
                 return node.get('project'), node.get('package', None)
         except urllib2.HTTPError, e:
-            if e.code == 404:
-                pass
+            if e.code != 404:
+                raise e
         return None, None
 
     def can_accept_review(self, request_id):


### PR DESCRIPTION
- 164b04903cfc56828b08e0fbb6041d3cb15c6e67:
    ReviewBot: add_review(): remove left-over print() line.

- d565f46123bc7208f034bfc8c2388a0eb4c79081:
    ReviewBot: get_devel_project(): correct error handling to only allow 404.
    
    The original intent was clearly to allow 404 (package does not exist for
    new packages), but crash on anything else. Instead it consumes all
    exceptions and does nothing different even with the e.code condition.