### PR TITLE
stagingapi: Ensure the links is valid before processing

### DIFF
--- a/osclib/stagingapi.py
+++ b/osclib/stagingapi.py
@@ -1072,17 +1072,17 @@ class StagingAPI(object):
 
         return project
 
-    def get_sub_packages(self, pkg, project=None):
+    def get_sub_packages(self, package, project=None):
         """
         Returns a list of packages that need to be linked into rings
         too. A package is actually a tuple of project and package name
         """
         ret = []
         if not project:
-            project = self.ring_packages.get(pkg)
+            project = self.ring_packages.get(package)
         if not project:
             return ret
-        url = self.makeurl(['source', project, pkg],
+        url = self.makeurl(['source', project, package],
                            {'cmd': 'showlinked'})
 
         # showlinked is a POST for rather bizzare reasons
@@ -1090,7 +1090,9 @@ class StagingAPI(object):
         root = ET.parse(f).getroot()
 
         for pkg in root.findall('package'):
-            ret.append((pkg.get('project'), pkg.get('name')))
+            # ensure sub-package is valid
+            if pkg.get('project') in self.rings and pkg.get('name') != package:
+                ret.append((pkg.get('project'), pkg.get('name')))
 
         return ret
 


### PR DESCRIPTION
Make sure the links of package in Rings must are valid before processing, otherwise someone had package linked to the Ring package in somewhere else than Rings will breaks select/delete/rm_to_prj, ie. _link will be created. Therefore, only return the candidate if it has proper linked from another ring and have different package name.

Example of failure:
```
mlin@rana:~> osc api -X POST `/source/openSUSE:Factory:Rings:2-TestDVD/telepathy-logger-qt5?cmd=showlinked
<collection>
    <package project="home:Vogtinator:branches:openSUSE:Factory:Rings:2-TestDVD" name="telepathy-logger-qt5"/>
</collection>
```