### PR TITLE
stagingapi: avoid making an empty package-diff comment.

### DIFF
--- a/osclib/stagingapi.py
+++ b/osclib/stagingapi.py
@@ -1481,6 +1481,9 @@ class StagingAPI(object):
                     req['prefix'] = 'removed '
                     requests.append(req)
 
+            if not len(requests):
+                # Nothing changed so no sense posting comment.
+                return
         else:
             dashboard_url = '{}/project/staging_projects/{}/{}'.format(
                 self.apiurl, self.project, self.extract_staging_short(project))


### PR DESCRIPTION
In the say way that I had to rework the supersede logic to actually keep track of what changes were made to print messages indicating the changes the select and unselect commands should likely know if the command they were asked to evaluate ended up doing nothing rather than just calling `update_status_or_deactivate()` always. Short of that ends up not being an issue except for `update_status_comments()` so just check for empty `package-diff` comments to avoid making them.

Fixes #1081.