### PR TITLE
ReviewBot: simplify logger format.

### DIFF
--- a/ReviewBot.py
+++ b/ReviewBot.py
@@ -513,7 +513,7 @@ class CommandLineInterface(cmdln.Cmdln):
         elif (self.options.verbose):
             level = logging.INFO
 
-        logging.basicConfig(level=level)
+        logging.basicConfig(level=level, format='[%(levelname).1s] %(message)s')
         self.logger = logging.getLogger(self.optparser.prog)
 
         conf.get_config(override_apiurl = self.options.apiurl)


### PR DESCRIPTION
The output is rather verbose, especially inside journals, and not terribly helpful.

```
[D] openSUSE:Factory:Staging:M:DVD/i586 not available
[I] cycle check: start
[I] cycle check: passed
[I] install check: start
[I] install check: passed
[D] no previous comment to replace on openSUSE:Factory:Staging:M
[I] can't change state, 517044 does not have the reviewer
[I] 517044 accepted: cycle and install check passed
[D] 517044 review not changed
```

vs (similar output)

```
INFO:repo_checker.py:install check: failed
INFO:repo_checker.py:mirroring openSUSE:Factory/standard/i586
DEBUG:repo_checker.py:openSUSE:Factory:Staging:adi:259/i586 not available
INFO:repo_checker.py:cycle check: start
INFO:repo_checker.py:cycle check: passed
INFO:repo_checker.py:install check: start
INFO:repo_checker.py:install check: failed
DEBUG:repo_checker.py:removing previous comment on openSUSE:Factory:Staging:adi:259
```