### PR TITLE
repo_checker: post passed comment only if previous failed comment (and debug improvements).

### DIFF
--- a/ReviewBot.py
+++ b/ReviewBot.py
@@ -435,7 +435,7 @@ class ReviewBot(object):
         self.comment_handler.lines = list(OrderedDict.fromkeys(self.comment_handler.lines))
 
     def comment_write(self, state='done', result=None, project=None, package=None,
-                      request=None, message=None, identical=False):
+                      request=None, message=None, identical=False, only_replace=False):
         """Write comment from log messages if not similar to previous comment."""
         if project:
             kwargs = {'project_name': project}
@@ -470,6 +470,9 @@ class ReviewBot(object):
             self.logger.debug('removing previous comment on {}'.format(debug_key))
             if not self.dryrun:
                 self.comment_api.delete(comment['id'])
+        elif only_replace:
+            self.logger.debug('no previous comment to replace on {}'.format(debug_key))
+            return
 
         self.logger.debug('adding comment to {}: {}'.format(debug_key, message))
         if not self.dryrun:

--- a/ReviewBot.py
+++ b/ReviewBot.py
@@ -463,14 +463,16 @@ class ReviewBot(object):
             self.logger.debug('previous comment too similar on {}'.format(debug_key))
             return
 
-        self.logger.debug('adding comment to {}: {}'.format(debug_key, message))
-
-        if not self.dryrun:
-            if comment is None:
-                # Broaden search to include any comment state.
-                comment, _ = self.comment_api.comment_find(comments, self.bot_name)
-            if comment is not None:
+        if comment is None:
+            self.logger.debug('broadening search to include any state on {}'.format(debug_key))
+            comment, _ = self.comment_api.comment_find(comments, self.bot_name)
+        if comment is not None:
+            self.logger.debug('removing previous comment on {}'.format(debug_key))
+            if not self.dryrun:
                 self.comment_api.delete(comment['id'])
+
+        self.logger.debug('adding comment to {}: {}'.format(debug_key, message))
+        if not self.dryrun:
             self.comment_api.add_comment(comment=str(message), **kwargs)
 
         self.comment_handler_remove()

--- a/ReviewBot.py
+++ b/ReviewBot.py
@@ -460,7 +460,7 @@ class ReviewBot(object):
              (not identical and comment['comment'].count('\n') == message.count('\n')))
         ):
             # Assume same state/result and number of lines in message is duplicate.
-            self.logger.debug('previous comment on {} too similar'.format(debug_key))
+            self.logger.debug('previous comment too similar on {}'.format(debug_key))
             return
 
         self.logger.debug('adding comment to {}: {}'.format(debug_key, message))

--- a/repo_checker.py
+++ b/repo_checker.py
@@ -187,6 +187,11 @@ class RepoChecker(ReviewBot.ReviewBot):
             # Some checks in group did not pass, post comment.
             self.comment_write(state='seen', result='failed', project=group,
                                message='\n'.join(comment).strip(), identical=True)
+        else:
+            # Post passed comment only if previous failed comment.
+            text = 'Previously reported problems have been resolved.'
+            self.comment_write(state='done', result='passed', project=group,
+                               message=text, identical=True, only_replace=True)
 
         return self.group_pass
 


### PR DESCRIPTION
- ad9f76bf4618081958a0bd491c0d1750b25fd7b5:
    repo_checker: post passed comment only if previous failed comment.

- ebd2f580ec2ddf13e23c6beb88ec625bffd183fe:
    ReviewBot: comment_write(): provide only_replace option.

- ca13855d2e8829b70df2f446d347164db586a883:
    ReviewBot: comment_write(): pull dryrun protected bit out individually.

- 757d31cf35ab19605b4ea989beda74e3669ad4af:
    ReviewBot: comment_write(): place debug_key at the end for consistency.

If turns out to be handy, it could be useful for other bots to behave in a similar fashion.