### PR TITLE
commentapi: provide truncate() and apply during add_comment() (and use in repo_checker).

### DIFF
--- a/repo_checker.py
+++ b/repo_checker.py
@@ -63,14 +63,12 @@ class RepoChecker(ReviewBot.ReviewBot):
         self.logger.info('{} package comments'.format(len(self.package_results)))
 
         for package, sections in self.package_results.items():
+            message = 'The version of this package in `{}` has installation issues and may not be installable:'.format(project)
+
             # Sort sections by text to group binaries together.
             sections = sorted(sections, key=lambda s: s.text)
-            message = '\n'.join([section.text for section in sections])
-            if len(message) > 16384:
-                # Truncate messages to avoid crashing OBS.
-                message = message[:16384 - 3] + '...'
-            message = '```\n' + message.strip() + '\n```'
-            message = 'The version of this package in `{}` has installation issues and may not be installable:\n\n'.format(project) + message
+            message += '\n\n<pre>\n{}\n</pre>'.format(
+                '\n'.join([section.text for section in sections]).strip())
 
             # Generate a hash based on the binaries involved and the number of
             # sections. This eliminates version or release changes from causing

--- a/tests/comment_tests.py
+++ b/tests/comment_tests.py
@@ -1,0 +1,48 @@
+from osclib.comments import CommentAPI
+import re
+import unittest
+
+
+class TestComment(unittest.TestCase):
+    def setUp(self):
+        self.api = CommentAPI('bogus')
+
+    def test_truncate(self):
+        comment = "string of text"
+        for i in xrange(len(comment) + 1):
+            truncated = self.api.truncate(comment, length=i)
+            print(truncated)
+            self.assertEqual(len(truncated), i)
+
+    def test_truncate_pre(self):
+        comment = """
+Some text.
+
+<pre>
+bar
+mar
+car
+</pre>
+
+## section 2
+
+<pre>
+more
+lines
+than
+you
+can
+handle
+</pre>
+""".strip()
+
+        for i in xrange(len(comment) + len('...\n</pre>')):
+            truncated = self.api.truncate(comment, length=i)
+            print('=' * 80)
+            print(truncated)
+            self.assertTrue(len(truncated) <= i, '{} <= {}'.format(len(truncated), i))
+            self.assertEqual(truncated.count('<pre>'), truncated.count('</pre>'))
+            self.assertFalse(len(re.findall(r'</?\w+[^\w>]', truncated)))
+            tag_count = truncated.count('<pre>') + truncated.count('</pre>')
+            self.assertEqual(tag_count, truncated.count('<'))
+            self.assertEqual(tag_count, truncated.count('>'))


### PR DESCRIPTION
- c8ee7dc2cf2034ace88d56c69766ee81fc8cf7d2:
    repo_checker: package_comments(): drop truncation in favor of commentapi.

- b8dc98a6e93efb423ed8d4bce38358cb0796ea36:
    commentapi: provide truncate() and apply during add_comment().

Current limit from openSUSE/open-build-service#3584, but should likely be lower due to serialization in openSUSE/open-build-service#3638.

Fixes #1061. All comments will now automatically be truncated while handling preformatted text and not breaking tags or leaving unbalanced tags.