### PR TITLE
cycle: remove ugly ignore code from _get_builddepinfo_graph().

### DIFF
--- a/osclib/cycle.py
+++ b/osclib/cycle.py
@@ -171,8 +171,6 @@ class CycleDetector(object):
     def _get_builddepinfo_graph(self, project, repository, arch):
         """Generate the buildepinfo graph for a given architecture."""
 
-        _IGNORE_PREFIX = ('texlive-', 'master-boot-code')
-
         # Note, by default generate the graph for all Factory /
         # 13/2. If you only need the base packages you can use:
         #   project = 'Base:System'
@@ -182,11 +180,6 @@ class CycleDetector(object):
         # Reset the subpackages dict here, so for every graph is a
         # different object.
         packages = [Package(element=e) for e in root.findall('package')]
-
-        # XXX - Ugly Exception. We need to ignore branding packages and
-        # packages that one of his dependencies do not exist. Also ignore
-        # preinstall images.
-        packages = [p for p in packages if not ('branding' in p.pkg or p.pkg.startswith('preinstallimage-'))]
 
         graph = Graph()
         graph.add_nodes_from((p.pkg, p) for p in packages)
@@ -203,19 +196,15 @@ class CycleDetector(object):
 
         for p in packages:
             # Calculate the missing deps
-            deps = [d for d in p.deps if 'branding' not in d]
-            missing = [d for d in deps if not d.startswith(_IGNORE_PREFIX) and d not in subpkgs]
+            deps = p.deps
+            missing = set(deps) - set(subpkgs)
             if missing:
                 if p.pkg not in self._ignore_packages:
                     # print 'Ignoring package. Missing dependencies %s -> (%s) %s...' % (p.pkg, len(missing), missing[:5])
                     self._ignore_packages.add(p.pkg)
                 continue
 
-            # XXX - Ugly Hack. Subpagackes for texlive are not correctly
-            # generated. If the dependency starts with texlive- prefix,
-            # assume that the correct source package is texlive.
-            graph.add_edges_from((p.pkg, subpkgs[d] if not d.startswith('texlive-') else 'texlive')
-                                 for d in deps if not d.startswith('master-boot-code'))
+            graph.add_edges_from((p.pkg, subpkgs[d]) for d in deps)
 
         # Store the subpkgs dict in the graph. It will be used later.
         graph.subpkgs = subpkgs


### PR DESCRIPTION
With the new repo_checker utilizing the staging process none of this should be necessary.

I ran against the texlive staging a few days ago, but could wait for another to confirm. All of the other ignore lists were removed in main `repo_checker` as the root cause seemed to be mixing devel project packages deps with target project which is no longer done.

These packages are in rings, so they are checked during any letter staging review and those pass with this code as well.