### PR TITLE
stagingapi: refactor get_sub_packages() to support adi package

### DIFF
--- a/osclib/stagingapi.py
+++ b/osclib/stagingapi.py
@@ -836,7 +836,6 @@ class StagingAPI(object):
         subprj = self.map_ring_package_to_subject(project, package)
         if self._supersede:
             self.is_package_disabled(subprj, package, store=True)
-        delete_package(self.apiurl, subprj, package, force=True, msg=msg)
 
         for sub_prj, sub_pkg in self.get_sub_packages(package, project):
             sub_prj = self.map_ring_package_to_subject(project, sub_pkg)
@@ -844,6 +843,9 @@ class StagingAPI(object):
                 self.is_package_disabled(sub_prj, sub_pkg, store=True)
             if sub_prj != subprj:  # if different to the main package's prj
                 delete_package(self.apiurl, sub_prj, sub_pkg, force=True, msg=msg)
+
+        # Delete the main package in the last
+        delete_package(self.apiurl, subprj, package, force=True, msg=msg)
 
         self.set_review(request_id, project, state=review, msg=msg)
 


### PR DESCRIPTION
The new logic is introduced, the description is below:
* If adi package: return sub-package list according to the specfiles of main package.
* If ring package: return sub-package list by showlinked call and the sub-package must be in another ring.
* The others: return empty list, no reason to return anything or even checking it in the devel project. Otherwise selecting a non-ring package to a letter staging probably would created unneeded sub-package.

With this, https://github.com/openSUSE/osc-plugin-factory/pull/948 should work.