### PR TITLE
ReviewBot: comment_write(): skip posting empty comments extracted from handler.

### DIFF
--- a/ReviewBot.py
+++ b/ReviewBot.py
@@ -445,8 +445,12 @@ class ReviewBot(object):
             if request is None:
                 request = self.request
             kwargs = {'request_id': request.reqid}
+        debug_key = '/'.join(kwargs.values())
 
         if message is None:
+            if not len(self.comment_handler.lines):
+                self.logger.debug('skipping empty comment for {}'.format(debug_key))
+                return
             message = '\n\n'.join(self.comment_handler.lines)
 
         info = {'state': state, 'result': result}
@@ -454,7 +458,6 @@ class ReviewBot(object):
 
         comments = self.comment_api.get_comments(**kwargs)
         comment, _ = self.comment_api.comment_find(comments, self.bot_name, info)
-        debug_key = '/'.join(kwargs.values())
         if (comment is not None and
             ((identical and comment['comment'] == message) or
              (not identical and comment['comment'].count('\n') == message.count('\n')))

--- a/ReviewBot.py
+++ b/ReviewBot.py
@@ -215,7 +215,7 @@ class ReviewBot(object):
                 # Only duplicate when allow_duplicate and state != new.
                 (not allow_duplicate or r.state == 'new')):
                 del query['cmd']
-                self.logger.info('skipped adding duplicate review for {}'.format(
+                self.logger.debug('skipped adding duplicate review for {}'.format(
                     '/'.join(query.values())))
                 return
 


### PR DESCRIPTION
- eb350bdf73a2d4dd62dd9878808117fdc4ad43da:
    ReviewBot: comment_write(): skip posting empty comments extracted from handler.

- 17d8ea8b3a606b161f778df3bc0afd1ea4fb8580:
    ReviewBot: downgrade message about skipping duplicate review to debug.
    
    This matches the original intent along with ensuring such messages never
    end up in the default CommentFromLogHandler.

Such comments are possible post #1100.