### PR TITLE
osclib/request_splitter: for SLE, fallback to openSUSE:Factory devel projects.

### DIFF
--- a/osclib/list_command.py
+++ b/osclib/list_command.py
@@ -36,8 +36,7 @@ class ListCommand:
         splitter.group_by('./action/target/@devel_project')
         splitter.split()
 
-        hide_source = (self.api.project == 'openSUSE:Factory' or
-                       self.api.project.startswith('SUSE:SLE'))
+        hide_source = self.api.project == 'openSUSE:Factory'
         for group in sorted(splitter.grouped.keys()):
             print Fore.YELLOW + group
 

--- a/osclib/list_command.py
+++ b/osclib/list_command.py
@@ -10,6 +10,7 @@ class ListCommand:
         'SUSE:SLE-12-',
         'openSUSE:Leap:'
         'openSUSE:',
+        'openSUSE.org:',
         'home:',
     ]
 

--- a/osclib/request_splitter.py
+++ b/osclib/request_splitter.py
@@ -146,6 +146,12 @@ class RequestSplitter(object):
         devel = self.api.get_devel_project(target_project, target_package)
         if devel is None and self.api.project.startswith('openSUSE:'):
             devel = self.api.get_devel_project('openSUSE:Factory', target_package)
+        if devel is None and self.api.project.startswith('SUSE:'):
+            # For SLE, fallback to openSUSE:Factory devel projects.
+            devel = self.api.get_devel_project('openSUSE.org:openSUSE:Factory', target_package)
+            if devel:
+                # Strip openSUSE.org: prefix since string since not used for lookup.
+                devel = devel.split(':', 1)[1]
         return devel
 
     def filter_check(self, request):


### PR DESCRIPTION
This change allows SLE to more effectively use `--try-strategies` since `devel` and `super` strategies have useful grouping information. It also effects `adi` and `list` command output grouping. As such I would like those involved with SLE to agree that the output change is desirable.

```
00
  139414 dmapi                          -> 1-MinimalX   (delete request)
         needs changes in installation-images
  139651 ffado-mixer                    -> delete       (delete request)
home:RBrownSUSE:branches:SUSE:SLE-15:GA
  139609 patterns-sle                   -> 1-MinimalX  
openSUSE.org:openSUSE:Factory
  137876 libquvi-scripts                -> 1-MinimalX  
         problematic for now
  137881 lua51                          -> 1-MinimalX  
         problematic for now
  137882 lua52                          -> 1-MinimalX  
         problematic for now
  138787 inkscape                       -> 1-MinimalX  
         breaks things for now
  138789 libguestfs                     -> 1-MinimalX  
         breaks things for now
  139219 dummy-release                  -> 1-MinimalX  
         breaks at least libguestfs and possibly apcupsd
  139222 libquicktime                   -> 1-MinimalX  
         breaks things for now
  139225 gnutls                         -> 1-MinimalX  
         breaks emacs (in B)
  139263 ffmpeg                         -> 1-MinimalX  
         breaks things for now
  139297 tpm2.0-tools                   -> 1-MinimalX  
         breaks things for now
```

vs (new output below)

```
Base:System
  139219 dummy-release                  -> 1-MinimalX  
         breaks at least libguestfs and possibly apcupsd
  139225 gnutls                         -> 1-MinimalX  
         breaks emacs (in B)
Virtualization
  138789 libguestfs                     -> 1-MinimalX  
         breaks things for now
devel:languages:lua
  137881 lua51                          -> 1-MinimalX  
         problematic for now
  137882 lua52                          -> 1-MinimalX  
         problematic for now
filesystems
  139414 dmapi                          -> 1-MinimalX   (delete request)
         needs changes in installation-images
graphics
  138787 inkscape                       -> 1-MinimalX  
         breaks things for now
multimedia:libs
  137876 libquvi-scripts                -> 1-MinimalX  
         problematic for now
  139222 libquicktime                   -> 1-MinimalX  
         breaks things for now
  139263 ffmpeg                         -> 1-MinimalX  
         breaks things for now
security
  139297 tpm2.0-tools                   -> 1-MinimalX  
         breaks things for now
```

If the fact that request from `openSUSE:Factory` is important (seems like it might be nice to see) we can remove SLE from `hide_source` list like `Leap` to produce:

```
Base:System
  139219 dummy-release                  -> 1-MinimalX   (openSUSE.org:openSUSE:Factory)
         breaks at least libguestfs and possibly apcupsd
  139225 gnutls                         -> 1-MinimalX   (openSUSE.org:openSUSE:Factory)
         breaks emacs (in B)
Virtualization
  138789 libguestfs                     -> 1-MinimalX   (openSUSE.org:openSUSE:Factory)
         breaks things for now
devel:languages:lua
  137881 lua51                          -> 1-MinimalX   (openSUSE.org:openSUSE:Factory)
         problematic for now
  137882 lua52                          -> 1-MinimalX   (openSUSE.org:openSUSE:Factory)
         problematic for now
filesystems
  139414 dmapi                          -> 1-MinimalX   (delete request)
         needs changes in installation-images
graphics
  138787 inkscape                       -> 1-MinimalX   (openSUSE.org:openSUSE:Factory)
         breaks things for now
multimedia:libs
  137876 libquvi-scripts                -> 1-MinimalX   (openSUSE.org:openSUSE:Factory)
         problematic for now
  139222 libquicktime                   -> 1-MinimalX   (openSUSE.org:openSUSE:Factory)
         breaks things for now
  139263 ffmpeg                         -> 1-MinimalX   (openSUSE.org:openSUSE:Factory)
         breaks things for now
security
  139297 tpm2.0-tools                   -> 1-MinimalX   (openSUSE.org:openSUSE:Factory)
         breaks things for now
```