### PR TITLE
Handle set_bugowner requests to avoid mixing them where they do not belong

### DIFF
--- a/osclib/list_command.py
+++ b/osclib/list_command.py
@@ -32,7 +32,7 @@ class ListCommand:
         change_devel_requests = splitter.filter_only()
         splitter.reset()
 
-        splitter.filter_add('./action[not(@type="add_role" or @type="change_devel")]')
+        splitter.filter_add('./action[@type="submit" or @type="delete"]')
         splitter.group_by('./action/target/@devel_project')
         splitter.split()
 

--- a/osclib/request_finder.py
+++ b/osclib/request_finder.py
@@ -65,7 +65,7 @@ class RequestFinder(object):
         :param package: name of the package
         """
 
-        query = 'states=new,review&project={}&view=collection&package={}'
+        query = 'types=submit,delete&states=new,review&project={}&view=collection&package={}'
         query = query.format(self.api.project, urllib2.quote(package))
         url = makeurl(self.api.apiurl, ['request'], query)
         f = http_GET(url)
@@ -100,7 +100,7 @@ class RequestFinder(object):
         :param newcand: the review state of staging-group must be new
         """
 
-        query = 'states=new,review&project={}&view=collection'.format(self.api.project)
+        query = 'types=submit,delete&states=new,review&project={}&view=collection'.format(self.api.project)
         url = makeurl(self.api.apiurl, ['request'], query)
         f = http_GET(url)
         root = ET.parse(f).getroot()


### PR DESCRIPTION
- 0f869ab8867dbe15b41b9bf0978141879e947a6a:
    osclib/request_finder: restrict to submit and delete request types.
    
    This avoid set_bugowner and change_devel requests from causing a select
    command to die due to more than one request.

- 77e70feef706eb184ea5c64992931a998d430314:
    osclib/list: rework change_devel_requests to include set_bugowner.
    
    Since set_bugowner requests are essentially equivalent to Factory
    change_devel requests they should be presented in the same manor.

- 4234706f30bcfe00e39532b1c83d8fb698c5bcc9:
    osclib/list: only present submit and delete requests in main list.

Should be verified by @coolo since SLE is the one having the problem, but openSUSE will benefit from not crashing if people make these type of requests.