### PR TITLE
Do not use direct flag for images

### DIFF
--- a/osclib/freeze_command.py
+++ b/osclib/freeze_command.py
@@ -210,7 +210,7 @@ class FreezeCommand(object):
             a = ET.SubElement(r, 'arch')
             a.text = arch
 
-        r = ET.SubElement(root, 'repository', {'name': 'images', 'linkedbuild': 'all', 'rebuild': 'direct'})
+        r = ET.SubElement(root, 'repository', {'name': 'images', 'linkedbuild': 'all'})
         ET.SubElement(r, 'path', {'project': prj, 'repository': 'standard'})
 
         if prj.startswith('SUSE:'):

--- a/tests/fixtures/staging-meta-for-bootstrap-copy.xml
+++ b/tests/fixtures/staging-meta-for-bootstrap-copy.xml
@@ -24,7 +24,7 @@
     <arch>x86_64</arch>
     <arch>ppc64le</arch>
   </repository>
-  <repository linkedbuild="all" name="images" rebuild="direct">
+  <repository linkedbuild="all" name="images">
     <path project="openSUSE:Factory:Staging:A" repository="standard"/>
     <arch>x86_64</arch>
     <arch>ppc64le</arch>


### PR DESCRIPTION
Products are too touchy - I had now 3 cases where the product would not
rebuild if a meta package changed