### PR TITLE
freeze_command: update product version for openSUSE only

### DIFF
--- a/osclib/freeze_command.py
+++ b/osclib/freeze_command.py
@@ -157,15 +157,16 @@ class FreezeCommand(object):
                 self.update_product_version(prj, 'Test-DVD-' + arch, arch, version)
 
         # now try to freeze sub project - much easier
-        if self.api.item_exists(prj + ':DVD') and self.api.item_exists(prj, "openSUSE-release"):
+        if self.api.item_exists(prj + ':DVD'):
             self.prj = prj + ':DVD'
             self.set_links()
             self.freeze_prjlinks()
 
             # Update the version information found in the Test-DVD package, to match openSUSE-release
-            version = self.api.package_version(prj, 'openSUSE-release')
-            for arch in ['x86_64', 'ppc64le']:
-                self.update_product_version(prj + ':DVD', 'Test-DVD-' + arch, arch, version)
+            if self.api.item_exists(prj, "openSUSE-release"):
+                version = self.api.package_version(prj, 'openSUSE-release')
+                for arch in ['x86_64', 'ppc64le']:
+                    self.update_product_version(prj + ':DVD', 'Test-DVD-' + arch, arch, version)
 
         # Set the original build status for the project
         self.api.build_switch_prj(prj, build_status)


### PR DESCRIPTION
Make freeze SLE Staging's DVD subproject can work. Update product version is necessary for openSUSE only.