### PR TITLE
Implements virtually accept the delete request

### DIFF
--- a/osclib/conf.py
+++ b/osclib/conf.py
@@ -44,6 +44,8 @@ DEFAULT = {
         'openqa': 'https://openqa.opensuse.org',
         'lock': 'openSUSE:%(project)s:Staging',
         'lock-ns': 'openSUSE',
+        'delreq-review': 'factory-maintainers',
+        'main-repo': 'standard',
     },
     r'openSUSE:(?P<project>Leap:[\d.]+)': {
         'staging': 'openSUSE:%(project)s:Staging',

--- a/tests/api_tests.py
+++ b/tests/api_tests.py
@@ -232,7 +232,7 @@ class TestApiCalls(unittest.TestCase):
             self.assertEqual('new', self.obs.requests[rq]['review'])
             self.assertEqual('review', self.obs.requests[rq]['request'])
             self.assertEqual(self.api.get_prj_pseudometa('openSUSE:Factory:Staging:A'),
-                             {'requests': [{'id': 123, 'package': 'gcc', 'author': 'Admin'}]})
+                    {'requests': [{'id': 123, 'package': 'gcc', 'author': 'Admin', 'type': 'submit'}]})
 
     def test_create_package_container(self):
         """Test if the uploaded _meta is correct."""

--- a/tests/obs.py
+++ b/tests/obs.py
@@ -228,8 +228,8 @@ class OBS(object):
             'C': {
                 'project': 'openSUSE:Factory:Staging:C',
                 'title': 'A project ready to be accepted',
-                'description': ('requests:\n- {id: 501, package: apparmor, author: Admin}\n'
-                                '- {id: 502, package: mariadb, author: Admin}'),
+                'description': ('requests:\n- {id: 501, package: apparmor, author: Admin, type: submit}\n'
+                    '- {id: 502, package: mariadb, author: Admin, type: submit}'),
             },
             'J': {
                 'project': 'openSUSE:Factory:Staging:J',
@@ -588,7 +588,7 @@ class OBS(object):
 
             meta = self.meta[key]
             # Simulate missing _meta revision missing puppet request.
-            meta = meta.replace('- {author: Admin, id: 321, package: puppet}', '')
+            meta = meta.replace('- {author: Admin, id: 321, package: puppet, type: submit}', '')
             response = (200, headers, meta)
         except Exception as e:
             if DEBUG:


### PR DESCRIPTION
https://progress.opensuse.org/issues/20420

Workflow:
* selecting a request to a staging, the pseudometa is changed to 
{id: 100, package: FOO, author: user, type: submit}
{id: 101, package: BAR, author: user, type: delete}

* during accepting a delete request:
If 'type' is exists in pseudometa and delreq-monitor was set in conf.py, the delete request will through *virtual accept* process, the binary will be removed on standard repo. If 'type' is not exists, go through the old route make sure it will not break the current stuff.

* in the later check-in round:
If it has found the virtual accepted request's package doesn't have binary on any build repo in the main project, the accept command accepts delreq-monitor review and continue accepts this request to the main project via accept_other_new().