### PR TITLE
rm_from_prj: always use the origin project path to set_review()

### DIFF
--- a/osclib/stagingapi.py
+++ b/osclib/stagingapi.py
@@ -832,6 +832,7 @@ class StagingAPI(object):
         if not package or not request_id:
             return
 
+        orig_project = project
         self._remove_package_from_prj_pseudometa(project, package)
         project = self.map_ring_package_to_subject(project, package)
         if self._supersede:
@@ -848,7 +849,7 @@ class StagingAPI(object):
         # Delete the main package in the last
         delete_package(self.apiurl, project, package, force=True, msg=msg)
 
-        self.set_review(request_id, project, state=review, msg=msg)
+        self.set_review(request_id, orig_project, state=review, msg=msg)
 
     def is_package_disabled(self, project, package, store=False):
         meta = show_package_meta(self.apiurl, project, package)


### PR DESCRIPTION
The variable project might got changed through map_ring_package_to_subject(), according to release process, we have to given the origin project path to set_review() always.

The case would like - a ring2 pacakge's review was a letter staging project and it can not be accepted as the `project` variable is changed to `$PROJECT:DVD` , accepts `:DVD` review is wrong. Regression from https://github.com/openSUSE/osc-plugin-factory/commit/831c73a3bc2cfca45bbb69a10244ad295329ea40