### PR TITLE
osclib/adi: include force=True when invoking delete_project().

### DIFF
--- a/osclib/adi_command.py
+++ b/osclib/adi_command.py
@@ -52,7 +52,7 @@ class AdiCommand:
                 packages.append(req['package'])
             self.api.accept_status_comment(project, packages)
             try:
-                delete_project(self.api.apiurl, project)
+                delete_project(self.api.apiurl, project, force=True)
             except urllib2.HTTPError, e:
                 print e
                 pass


### PR DESCRIPTION
If users build against an adi project OBS will refuse to delete, but in
that case breaking other projects is fine as the branches should only be
used to work on fixes seen in adi stagings.

See #1142 for an example, details, and discussion.

Fixes #1144.