### PR TITLE
adi_command: do not checking adi staging status if there is no selected_requests

### DIFF
--- a/osclib/adi_command.py
+++ b/osclib/adi_command.py
@@ -22,27 +22,28 @@ class AdiCommand:
     def check_adi_project(self, project):
         query_project = self.api.extract_staging_short(project)
         info = self.api.project_status(project, True)
-        if len(info['building_repositories']):
-            print query_project, Fore.MAGENTA + 'building'
-            return
-        if len(info['untracked_requests']):
-            print query_project, Fore.YELLOW + 'untracked:', ', '.join(['{}[{}]'.format(
-                Fore.CYAN + req['package'] + Fore.RESET, req['number']) for req in info['untracked_requests']])
-            return
-        if len(info['obsolete_requests']):
-            print query_project, Fore.YELLOW + 'obsolete:', ', '.join(['{}[{}]'.format(
-                Fore.CYAN + req['package'] + Fore.RESET, req['number']) for req in info['obsolete_requests']])
-            return
-        if len(info['broken_packages']):
-            print query_project, Fore.RED + 'broken:', ', '.join([
-                Fore.CYAN + p['package'] + Fore.RESET for p in info['broken_packages']])
-            return
-        for review in info['missing_reviews']:
-            print query_project, Fore.WHITE + 'review:', '{} for {}[{}]'.format(
-                Fore.YELLOW + review['by'] + Fore.RESET,
-                Fore.CYAN + review['package'] + Fore.RESET,
-                review['request'])
-            return
+        if len(info['selected_requests']):
+            if len(info['building_repositories']):
+                print query_project, Fore.MAGENTA + 'building'
+                return
+            if len(info['untracked_requests']):
+                print query_project, Fore.YELLOW + 'untracked:', ', '.join(['{}[{}]'.format(
+                    Fore.CYAN + req['package'] + Fore.RESET, req['number']) for req in info['untracked_requests']])
+                return
+            if len(info['obsolete_requests']):
+                print query_project, Fore.YELLOW + 'obsolete:', ', '.join(['{}[{}]'.format(
+                    Fore.CYAN + req['package'] + Fore.RESET, req['number']) for req in info['obsolete_requests']])
+                return
+            if len(info['broken_packages']):
+                print query_project, Fore.RED + 'broken:', ', '.join([
+                    Fore.CYAN + p['package'] + Fore.RESET for p in info['broken_packages']])
+                return
+            for review in info['missing_reviews']:
+                print query_project, Fore.WHITE + 'review:', '{} for {}[{}]'.format(
+                    Fore.YELLOW + review['by'] + Fore.RESET,
+                    Fore.CYAN + review['package'] + Fore.RESET,
+                    review['request'])
+                return
         if self.api.is_user_member_of(self.api.user, self.api.cstaging_group):
             print query_project, Fore.GREEN + 'ready'
             packages = []


### PR DESCRIPTION
Wihtout selected_requests then that adi staging project is an empty project, adi command should clean it up rather than go through the logic to check the project status. Since we have introduced a kind of frozenlinks adi staging, the project status might be build broken or so but it doesn't have any request
staged in that staging actually, those kind of projects must be deleted.