### PR TITLE
Include CLEANUP => 1 during temp directory creation in perl scripts.

### DIFF
--- a/check_source.pl
+++ b/check_source.pl
@@ -234,7 +234,7 @@ if (-d "$old") {
 }
 
 my $odir = getcwd;
-my $tmpdir = tempdir( "obs-XXXXXXX", TMPDIR => 1 );
+my $tmpdir = tempdir("obs-XXXXXXX", TMPDIR => 1, CLEANUP => 1);
 chdir($dir) || die 'tempdir failed';
 if (system("/usr/lib/obs/service/download_files","--enforceupstream", "yes", "--enforcelocal", "yes", "--outdir", $tmpdir)) {
     print "Source URLs are not valid. Try \"osc service localrun download_files\"\n";

--- a/rebuildpacs.pl
+++ b/rebuildpacs.pl
@@ -165,7 +165,7 @@ if (%torebuild) {
   system("osc api -X POST '$api'");
 }
 
-my $pfile = tempdir() . "/packages";    # the filename is important ;(
+my $pfile = tempdir(CLEANUP => 1) . "/packages";    # the filename is important ;(
 
 sub mirror_repo($$$) {
 


### PR DESCRIPTION
As noted by @DimStar77 the packagelists machine filled up `/tmp` and these two instances seem to at least leave directories behind and are thus worth fixing. It is also possible that the perl scripts crashing will leave behind the tmp directories.

I ran `check_source.py` locally and verified the fix works correctly before and after. Currently running `repo_checker.py`