### PR TITLE
check_source: allow usage by SLE to primarily add repo-checker review

### DIFF
--- a/check_source.py
+++ b/check_source.py
@@ -239,7 +239,7 @@ class CommandLineInterface(ReviewBot.CommandLineInterface):
         parser = ReviewBot.CommandLineInterface.get_optparser(self)
 
         parser.add_option('--ignore-devel', action='store_true', default=False, help='ignore devel projects for target package')
-        parser.add_option('--review-team', metavar='GROUP', help='review team group added to requests with > 8 diff')
+        parser.add_option('--review-team', metavar='GROUP', help='review team group added to requests')
         parser.add_option('--repo-checker', metavar='USER', help='repo checker user added after accepted review')
         parser.add_option('--staging-group', metavar='GROUP', help='group used by staging process')
         parser.add_option('--skip-add-reviews', action='store_true', default=False, help='skip adding review after completing checks')

--- a/check_source.py
+++ b/check_source.py
@@ -252,8 +252,12 @@ class CommandLineInterface(ReviewBot.CommandLineInterface):
         if self.options.ignore_devel:
             bot.ignore_devel = self.options.ignore_devel
         if self.options.review_team:
+            if self.options.review_team == 'None':
+                self.options.review_team = None
             bot.review_team = self.options.review_team
         if self.options.repo_checker:
+            if self.options.repo_checker == 'None':
+                self.options.repo_checker = None
             bot.repo_checker = self.options.repo_checker
         if self.options.staging_group:
             bot.staging_group = self.options.staging_group

--- a/check_source.py
+++ b/check_source.py
@@ -238,11 +238,11 @@ class CommandLineInterface(ReviewBot.CommandLineInterface):
     def get_optparser(self):
         parser = ReviewBot.CommandLineInterface.get_optparser(self)
 
-        parser.add_option('--ignore-devel', dest='ignore_devel', action='store_true', default=False, help='ignore devel projects for target package')
-        parser.add_option('--review-team', dest='review_team', metavar='GROUP', help='review team group added to requests with > 8 diff')
-        parser.add_option('--repo-checker', dest='repo_checker', metavar='USER', help='repo checker user added after accepted review')
+        parser.add_option('--ignore-devel', action='store_true', default=False, help='ignore devel projects for target package')
+        parser.add_option('--review-team', metavar='GROUP', help='review team group added to requests with > 8 diff')
+        parser.add_option('--repo-checker', metavar='USER', help='repo checker user added after accepted review')
         parser.add_option('--staging-group', metavar='GROUP', help='group used by staging process')
-        parser.add_option('--skip-add-reviews', dest='skip_add_reviews', action='store_true', default=False, help='skip adding review after completing checks')
+        parser.add_option('--skip-add-reviews', action='store_true', default=False, help='skip adding review after completing checks')
 
         return parser
 


### PR DESCRIPTION
- a825af82a0f9f04d2a82766556ebf8c4da6cec9a:
    check_source: lookup staging group using StagingAPI rather than flag.

- c081de602564c16b96e19de459621f3808b08a07:
    check_source: interpret "None" as python None for review-team and repo-checker.
    
    Allows for disabling adding those reviews from the command line.

- 1e9c389617b0b9f9dee77ef36cb27879652fd8de:
    check_source: drop inaccurate "with > 8 diff" from --review-team option.

- 73df8871f14812dabb78a6dac675e9fc7169b70c:
    check_source: drop unnecessary dest from add_option().

Fixes #1015.

For SLE `review-team` can be disabled and devel check disabled. Leap works with just devel check disabled.

```
./check_source.py -A ibs --debug --dry --ignore-devel --review-team None id 142766
[I] checking 142766
[I] openSUSE.org:openSUSE:Factory/console-setup@9979d4d0d4103aca0a1067e221fd614e -> SUSE:SLE-15:GA/console-setup
[I] POST https://api.suse.de/request/142766?cmd=addreview&by_user=repo-checker
[I] can't change state, 142766 does not have the reviewer
[I] 142766 accepted: Check script succeeded
[D] 142766 review not changed
```

For Factory, keeps functioning as it used to.

```
./check_source.py --debug --dry id 522873
[I] checking 522873
[I] network/atftp@34 -> openSUSE:Factory/atftp
[D] skipped adding duplicate review for opensuse-review-team
[D] skipped adding duplicate review for repo-checker
[I] can't change state, 522873 does not have the reviewer
[I] 522873 accepted: Check script succeeded
[D] 522873 review not changed
```