### PR TITLE
dist: provide repo-checker sub-package with binary in path, service, and user.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ SUBDIRS = factory-package-news abichecker
 
 include Makefile.common
 
+pkgdata_BINS=repo_checker
 pkgdata_SCRIPTS=$(wildcard *.py *.pl *.sh)
 pkgdata_SCRIPTS+=bs_mirrorfull findfileconflicts
 pkgdata_DATA+=bs_copy osclib $(wildcard *.pm *.testcase)
@@ -11,7 +12,7 @@ VERSION = "build-$(shell date +%F)"
 all:
 
 install:
-	install -d -m 755 $(DESTDIR)$(pkgdatadir) $(DESTDIR)$(unitdir) $(DESTDIR)$(oscplugindir)
+	install -d -m 755 $(DESTDIR)$(bindir) $(DESTDIR)$(pkgdatadir) $(DESTDIR)$(unitdir) $(DESTDIR)$(oscplugindir)
 	for i in $(pkgdata_SCRIPTS); do install -m 755 $$i $(DESTDIR)$(pkgdatadir); done
 	chmod 644 $(DESTDIR)$(pkgdatadir)/osc-*.py
 	for i in $(pkgdata_DATA); do cp -a $$i $(DESTDIR)$(pkgdatadir); done
@@ -20,6 +21,7 @@ install:
 	install -m 644 systemd/* $(DESTDIR)$(unitdir)
 	sed -i "s/OSC_STAGING_VERSION = '.*'/OSC_STAGING_VERSION = '$(VERSION)'/" \
 	  $(DESTDIR)$(pkgdatadir)/osc-staging.py
+	for i in $(pkgdata_BINS); do ln -s $(pkgdatadir)/$$i.py $(DESTDIR)$(bindir)/osrt-$$i; done
 
 check: test
 

--- a/Makefile.common
+++ b/Makefile.common
@@ -1,4 +1,5 @@
 prefix=/usr
+bindir=$(prefix)/bin
 datadir=$(prefix)/share
 sysconfdir=/etc
 unitdir=$(prefix)/lib/systemd/system

--- a/dist/package/openSUSE-release-tools.spec
+++ b/dist/package/openSUSE-release-tools.spec
@@ -105,6 +105,17 @@ BuildArch:      noarch
 %description announcer
 OBS product release announcer for generating email diffs summaries.
 
+%package repo-checker
+Summary:        Repository checker service
+Group:          Development/Tools/Other
+BuildArch:      noarch
+# TODO Update requirements.
+Requires:       osclib = %{version}
+Requires(pre):  shadow
+
+%description repo-checker
+Repository checker service that inspects built RPMs from stagings.
+
 %package totest-manager
 Summary:        Manages \$product:ToTest repository
 Group:          Development/Tools/Other
@@ -185,6 +196,21 @@ mkdir -p %{buildroot}%{_datadir}/%{source_dir}/%{announcer_filename}
 %postun announcer
 %service_del_postun %{announcer_filename}.service
 
+%pre repo-checker
+%service_add_pre osrt-repo-checker.service
+getent passwd osrt-repo-checker > /dev/null || \
+  useradd -r -m -s /sbin/nologin -c "user for openSUSE-release-tools-repo-checker" osrt-repo-checker
+exit 0
+
+%post repo-checker
+%service_add_post osrt-repo-checker.service
+
+%preun repo-checker
+%service_del_preun osrt-repo-checker.service
+
+%postun repo-checker
+%service_del_postun osrt-repo-checker.service
+
 %pre totest-manager
 %service_add_pre opensuse-totest-manager.service
 
@@ -203,6 +229,7 @@ mkdir -p %{buildroot}%{_datadir}/%{source_dir}/%{announcer_filename}
 %{_datadir}/%{source_dir}
 %exclude %{_datadir}/%{source_dir}/abichecker
 %exclude %{_datadir}/%{source_dir}/%{announcer_filename}
+%exclude %{_datadir}/%{source_dir}/repo_checker.py
 %exclude %{_datadir}/%{source_dir}/totest-manager.py
 %exclude %{_datadir}/%{source_dir}/osclib
 %exclude %{_datadir}/%{source_dir}/osc-check_dups.py
@@ -229,6 +256,15 @@ mkdir -p %{buildroot}%{_datadir}/%{source_dir}/%{announcer_filename}
 %config(noreplace) %{_sysconfdir}/rsyslog.d/%{announcer_filename}.conf
 %{_unitdir}/%{announcer_filename}.service
 %{_unitdir}/%{announcer_filename}.timer
+
+%files repo-checker
+%defattr(-,root,root,-)
+%{_bindir}/osrt-repo_checker
+%{_datadir}/%{source_dir}/repo_checker.py
+%{_unitdir}/osrt-repo-checker.service
+%{_unitdir}/osrt-repo-checker.timer
+%{_unitdir}/osrt-repo-checker-project_only@.service
+%{_unitdir}/osrt-repo-checker-project_only@.timer
 
 %files totest-manager
 %defattr(-,root,root,-)

--- a/dist/package/openSUSE-release-tools.spec
+++ b/dist/package/openSUSE-release-tools.spec
@@ -65,6 +65,10 @@ Requires:       python-python-dateutil
 Requires:       python-pyxdg
 Requires:       python-urlgrabber
 
+# bs_mirrorfull
+Requires:       perl-XML-Parser
+Requires:       perl-Net-SSLeay
+
 # Spec related requirements.
 Requires:       osclib = %{version}
 
@@ -111,6 +115,9 @@ Group:          Development/Tools/Other
 BuildArch:      noarch
 # TODO Update requirements.
 Requires:       osclib = %{version}
+# repo_checker.pl
+Requires:       perl-XML-Simple
+Requires:       build
 Requires(pre):  shadow
 
 %description repo-checker
@@ -229,6 +236,7 @@ exit 0
 %{_datadir}/%{source_dir}
 %exclude %{_datadir}/%{source_dir}/abichecker
 %exclude %{_datadir}/%{source_dir}/%{announcer_filename}
+%exclude %{_datadir}/%{source_dir}/repo_checker.pl
 %exclude %{_datadir}/%{source_dir}/repo_checker.py
 %exclude %{_datadir}/%{source_dir}/totest-manager.py
 %exclude %{_datadir}/%{source_dir}/osclib
@@ -260,6 +268,7 @@ exit 0
 %files repo-checker
 %defattr(-,root,root,-)
 %{_bindir}/osrt-repo_checker
+%{_datadir}/%{source_dir}/repo_checker.pl
 %{_datadir}/%{source_dir}/repo_checker.py
 %{_unitdir}/osrt-repo-checker.service
 %{_unitdir}/osrt-repo-checker.timer

--- a/repo_checker.py
+++ b/repo_checker.py
@@ -52,7 +52,7 @@ class RepoChecker(ReviewBot.ReviewBot):
             }
 
             if not all(result.success for _, result in results.items()):
-                self.result_comment(project, project, arch, results, comment)
+                self.result_comment(arch, results, comment)
 
         text = '\n'.join(comment).strip()
         api.dashboard_content_ensure('repo_checker', text, 'project_only run')

--- a/systemd/osrt-repo-checker-project_only@.service
+++ b/systemd/osrt-repo-checker-project_only@.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=openSUSE Release Tools: repo-checker project_only for %i
+
+[Service]
+Type=oneshot
+User=osrt-repo-checker
+SyslogIdentifier=osrt-repo-checker
+ExecStart=/usr/bin/osrt-repo_checker --debug project_only --post-comments "%i"
+TimeoutStartSec=8 hour
+
+[Install]
+WantedBy=multi-user.target

--- a/systemd/osrt-repo-checker-project_only@.timer
+++ b/systemd/osrt-repo-checker-project_only@.timer
@@ -1,0 +1,9 @@
+[Unit]
+Description=openSUSE Release Tools: repo-checker project_only for %i
+
+[Timer]
+OnCalendar=daily
+Unit=osrt-repo-checker-project_only@%i.service
+
+[Install]
+WantedBy=timers.target

--- a/systemd/osrt-repo-checker.service
+++ b/systemd/osrt-repo-checker.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=openSUSE Release Tools: repo-checker
+
+[Service]
+Type=oneshot
+User=osrt-repo-checker
+SyslogIdentifier=osrt-repo-checker
+ExecStart=/usr/bin/osrt-repo_checker --debug review
+TimeoutStartSec=8 hour
+
+[Install]
+WantedBy=multi-user.target

--- a/systemd/osrt-repo-checker.timer
+++ b/systemd/osrt-repo-checker.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=openSUSE Release Tools: repo-checker
+
+[Timer]
+OnBootSec=120
+OnUnitInactiveSec=5 min
+Unit=osrt-repo-checker.service
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
Should be first service compatible with #1006.

@lnussel: We can use to deploy for IBS.