### PR TITLE
ReviewBot: comment_write(): pre-truncate for correct comparison.

### DIFF
--- a/ReviewBot.py
+++ b/ReviewBot.py
@@ -480,7 +480,7 @@ class ReviewBot(object):
 
         self.logger.debug('adding comment to {}: {}'.format(debug_key, message))
         if not self.dryrun:
-            self.comment_api.add_comment(comment=str(message), **kwargs)
+            self.comment_api.add_comment(comment=message, **kwargs)
 
         self.comment_handler_remove()
 

--- a/ReviewBot.py
+++ b/ReviewBot.py
@@ -455,6 +455,7 @@ class ReviewBot(object):
 
         info = {'state': state, 'result': result}
         message = self.comment_api.add_marker(message, self.bot_name, info)
+        message = self.comment_api.truncate(message.strip())
 
         comments = self.comment_api.get_comments(**kwargs)
         comment, _ = self.comment_api.comment_find(comments, self.bot_name, info)

--- a/osclib/comments.py
+++ b/osclib/comments.py
@@ -136,8 +136,7 @@ class CommentAPI(object):
         if not comment:
             raise ValueError('Empty comment.')
 
-        # Always encode as utf-8 to ensure truncate handles length properly.
-        comment = self.truncate(comment.strip().encode('utf-8'))
+        comment = self.truncate(comment.strip())
 
         query = {}
         if parent_id:


### PR DESCRIPTION
- b97ced1c74e79e2a660af9e4f2115a7ca1f86f25:
    ReviewBot: comment_write() no need to str() since None is exits above.

- 642f0536a1a7c588dac341c31636fae42ca57418:
    ReviewBot: comment_write(): pre-truncate for correct comparison.
    
    Otherwise, long comments that end up being truncated are re-posted.

Fixes #1163.