### PR TITLE
check_source: Ensure the source and destination package name matches

### DIFF
--- a/check_source.py
+++ b/check_source.py
@@ -81,6 +81,11 @@ class CheckSource(ReviewBot.ReviewBot):
             self.review_messages['declined'] = "A package submitted as %s has to build as 'Name: %s' - found Name '%s'" % (target_package, target_package, new_info['name'])
             return False
 
+        # We want to see the same package name in the devel project as in the distro; anything else calls for confusion
+        if source_package != target_package:
+            self.review_messages['declined'] = "No in-air renames: The package must be called the same in the devel project as in the target project"
+            return False
+
         # Run check_source.pl script and interpret output.
         source_checker = os.path.join(CheckSource.SCRIPT_PATH, 'check_source.pl')
         civs = ''


### PR DESCRIPTION
https://build.opensuse.org/request/show/530180 is an example where this actually happened. Really not something we want to see