### PR TITLE
travis: include OBS_TARGET_PROJECT env variable during deploy script.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ matrix:
 
 deploy:
   provider: script
-  script: docker run -it -e OBS_PACKAGE="$OBS_PACKAGE" -e OBS_USER="$OBS_USER" -e OBS_PASS="$OBS_PASS" -e OBS_EMAIL="$OBS_EMAIL" spec ./dist/ci/deploy.obs.sh
+  script: docker run -it -e OBS_TARGET_PROJECT="$OBS_TARGET_PROJECT" -e OBS_PACKAGE="$OBS_PACKAGE" -e OBS_USER="$OBS_USER" -e OBS_PASS="$OBS_PASS" -e OBS_EMAIL="$OBS_EMAIL" spec ./dist/ci/deploy.obs.sh
   on:
     branch: master
     condition: $TEST_SUITE = distribution


### PR DESCRIPTION
Unfortunately, since nearly impossible to test deploy scripts as run by travis missed including environment variable during deployment run in #1171. The script itself works as I tested locally, but missed the variable so it ran `osc request list "" "openSUSE-release-tools"` which does not match grep and thus does not create submit.