### PR TITLE
dist/ci/deploy: wait for service to complete before create submit request (and automatically detect link)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 env:
   global:
-    - OBS_TARGET_PROJECT="openSUSE:Factory"
     - OBS_PACKAGE="openSUSE:Tools/openSUSE-release-tools"
     - OBS_USER="jberry"
     # OBS_PASS
@@ -37,7 +36,7 @@ matrix:
 
 deploy:
   provider: script
-  script: docker run -it -e OBS_TARGET_PROJECT="$OBS_TARGET_PROJECT" -e OBS_PACKAGE="$OBS_PACKAGE" -e OBS_USER="$OBS_USER" -e OBS_PASS="$OBS_PASS" -e OBS_EMAIL="$OBS_EMAIL" spec ./dist/ci/deploy.obs.sh
+  script: docker run -it -e OBS_PACKAGE="$OBS_PACKAGE" -e OBS_USER="$OBS_USER" -e OBS_PASS="$OBS_PASS" -e OBS_EMAIL="$OBS_EMAIL" spec ./dist/ci/deploy.obs.sh
   on:
     branch: master
     condition: $TEST_SUITE = distribution

--- a/dist/ci/deploy.obs.sh
+++ b/dist/ci/deploy.obs.sh
@@ -19,7 +19,10 @@ osc addremove
 osc commit -m "$(grep -oP 'version: \K.*' *.obsinfo)"
 
 # Create submit request if none currently exists.
-if osc request list "$OBS_TARGET_PROJECT" "$(cat .osc/_package)" | grep 'No results for package' ; then
+OBS_TARGET_PROJECT="$(osc info | grep -oP "Link info: project \K[^\s,]+")"
+OBS_TARGET_PACKAGE="$(osc info | grep -oP "Link info: .*, package \K[^\s,]+")"
+echo "checking for existing requests to $OBS_TARGET_PROJECT/$OBS_TARGET_PACKAGE..."
+if osc request list "$OBS_TARGET_PROJECT" "$OBS_TARGET_PACKAGE" | grep 'No results for package' ; then
   osc service wait
   osc sr --diff
   osc sr --yes -m "automatic update"

--- a/dist/ci/deploy.obs.sh
+++ b/dist/ci/deploy.obs.sh
@@ -24,6 +24,6 @@ OBS_TARGET_PACKAGE="$(osc info | grep -oP "Link info: .*, package \K[^\s,]+")"
 echo "checking for existing requests to $OBS_TARGET_PROJECT/$OBS_TARGET_PACKAGE..."
 if osc request list "$OBS_TARGET_PROJECT" "$OBS_TARGET_PACKAGE" | grep 'No results for package' ; then
   osc service wait
-  osc sr --diff
+  osc sr --diff | cat
   osc sr --yes -m "automatic update"
 fi

--- a/dist/ci/deploy.obs.sh
+++ b/dist/ci/deploy.obs.sh
@@ -20,6 +20,7 @@ osc commit -m "$(grep -oP 'version: \K.*' *.obsinfo)"
 
 # Create submit request if none currently exists.
 if osc request list "$OBS_TARGET_PROJECT" "$(cat .osc/_package)" | grep 'No results for package' ; then
+  osc service wait
   osc sr --diff
   osc sr --yes -m "automatic update"
 fi


### PR DESCRIPTION
Same reason as #1172, works, but too quick since after commit OBS spends a second or two try to run `_service` which ends up being a nop.

While I was at it made link detection automatic.

- 4161a7ec0dd7e09b707ffd3a558c57707f047b7b:
    dist/ci/deploy: pipe `osc sr --diff` to cat to ensure same behavior manually run.

- ace27a9385187d20052e19dfd12f61bb9f8e084b:
    dist/ci/deploy: automatically detect target project and package.

- a99faac2ba29c8a4a1b34f2cf9f6a629cee053b7:
    dist/ci/deploy: wait for service to complete before create submit request.