### PR TITLE
dist: rework totest-manager subpackage to provide new style service.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ SUBDIRS = factory-package-news abichecker
 
 include Makefile.common
 
-pkgdata_BINS=devel-project leaper manager_42 repo_checker suppkg_rebuild update_crawler
+pkgdata_BINS=devel-project leaper manager_42 repo_checker suppkg_rebuild totest-manager update_crawler
 pkgdata_SCRIPTS=$(wildcard *.py *.pl *.sh)
 pkgdata_SCRIPTS+=bs_mirrorfull findfileconflicts
 pkgdata_DATA+=bs_copy metrics osclib $(wildcard *.pm *.testcase)

--- a/dist/package/openSUSE-release-tools.spec
+++ b/dist/package/openSUSE-release-tools.spec
@@ -319,16 +319,19 @@ exit 0
 %service_del_postun osrt-staging-bot-support-rebuild@.service
 
 %pre totest-manager
-%service_add_pre opensuse-totest-manager.service
+%service_add_pre osrt-totest-manager@.service
+getent passwd osrt-totest-manager > /dev/null || \
+  useradd -r -m -s /sbin/nologin -c "user for openSUSE-release-tools-totest-manager" osrt-totest-manager
+exit 0
 
 %post totest-manager
-%service_add_post opensuse-totest-manager.service
+%service_add_post osrt-totest-manager@.service
 
 %preun totest-manager
-%service_del_preun opensuse-totest-manager.service
+%service_del_preun osrt-totest-manager@.service
 
 %postun totest-manager
-%service_del_postun opensuse-totest-manager.service
+%service_del_postun osrt-totest-manager@.service
 
 %files
 %defattr(-,root,root,-)
@@ -426,8 +429,9 @@ exit 0
 
 %files totest-manager
 %defattr(-,root,root,-)
-%{_unitdir}/opensuse-totest-manager.service
+%{_bindir}/osrt-totest-manager
 %{_datadir}/%{source_dir}/totest-manager.py
+%{_unitdir}/osrt-totest-manager@.service
 
 %files -n osclib
 %defattr(-,root,root,-)

--- a/dist/package/openSUSE-release-tools.spec
+++ b/dist/package/openSUSE-release-tools.spec
@@ -165,6 +165,7 @@ Group:          Development/Tools/Other
 BuildArch:      noarch
 # TODO Update requirements.
 Requires:       osclib = %{version}
+Requires:       python-openqa_client
 
 %description totest-manager
 Manages \$product:ToTest repository workflow and openQA interaction

--- a/dist/package/openSUSE-release-tools.spec
+++ b/dist/package/openSUSE-release-tools.spec
@@ -160,7 +160,7 @@ Requires(pre):  shadow
 Staging bot services and system user.
 
 %package totest-manager
-Summary:        Manages \$product:ToTest repository
+Summary:        Manages product ToTest repository
 Group:          Development/Tools/Other
 BuildArch:      noarch
 # TODO Update requirements.
@@ -168,7 +168,7 @@ Requires:       osclib = %{version}
 Requires:       python-openqa_client
 
 %description totest-manager
-Manages \$product:ToTest repository workflow and openQA interaction
+Manages product ToTest repository workflow and openQA interaction
 
 %package -n osclib
 Summary:        Supplemental osc libraries

--- a/systemd/opensuse-totest-manager.service
+++ b/systemd/opensuse-totest-manager.service
@@ -1,9 +1,0 @@
-[Unit]
-Description=openSUSE Factory ToTest Manager
-
-[Service]
-Type=simple
-ExecStart=/usr/bin/screen -DmS totest-manager /usr/share/osc-plugin-factory/totest-manager.py run --verbose --interval 15
-ExecStop=/usr/bin/screen -S totest-manager -X quit
-WorkingDirectory=/usr/share/osc-plugin-factory
-User=_opensuse.org-totest-manager

--- a/systemd/osrt-totest-manager@.service
+++ b/systemd/osrt-totest-manager@.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=openSUSE Release Tools: ToTest Manager for %i
+
+[Service]
+Type=simple
+User=osrt-totest-manager
+WorkingDirectory=~
+ExecStart=/usr/bin/osrt-totest-manager --verbose run --interval 5 "%i"


### PR DESCRIPTION
Another towards #1006.