### PR TITLE
check_source: move all relevant flags to config to work properly without flags.

### DIFF
--- a/check_source.py
+++ b/check_source.py
@@ -36,7 +36,7 @@ class CheckSource(ReviewBot.ReviewBot):
         super(CheckSource, self).check_source_submission(source_project, source_package, source_revision, target_project, target_package)
 
         if not self.ignore_devel:
-            # Check if target package exists and has devel project.
+            self.logger.info('checking if target package exists and has devel project')
             devel_project, devel_package = self.get_devel_project(target_project, target_package)
             if devel_project:
                 if (source_project != devel_project or source_package != devel_package) and \

--- a/osclib/conf.py
+++ b/osclib/conf.py
@@ -46,6 +46,10 @@ DEFAULT = {
         'lock-ns': 'openSUSE',
         'delreq-review': 'factory-maintainers',
         'main-repo': 'standard',
+        # check_source.py
+        'devel-project-enforce': 'True',
+        'review-team': 'opensuse-review-team',
+        'repo-checker': 'repo-checker',
     },
     r'openSUSE:(?P<project>Leap:[\d.]+)': {
         'staging': 'openSUSE:%(project)s:Staging',
@@ -62,6 +66,9 @@ DEFAULT = {
         'lock-ns': 'openSUSE',
         'delreq-review': None,
         'main-repo': 'standard',
+        # check_source.py
+        # review-team optionally added by leaper.py.
+        'repo-checker': 'repo-checker',
     },
     r'SUSE:(?P<project>SLE-15.*$)': {
         'staging': 'SUSE:%(project)s:Staging',
@@ -77,6 +84,8 @@ DEFAULT = {
         'lock-ns': 'SUSE',
         'delreq-review': None,
         'main-repo': 'standard',
+        # check_source.py
+        'repo-checker': 'repo-checker',
     },
     r'SUSE:(?P<project>.*$)': {
         'staging': 'SUSE:%(project)s:Staging',


### PR DESCRIPTION
- c05a26d154818b2725a1dc1e1d07d89df478a2a0:
    check_source: move all relevant flags to config to work properly without flags.

- 52af5b3d75a1840132b65c616e473def136f5840:
    check_source: print message if checking devel project.
    
    Currently, no indication unless ends in decline. More important when moving
    option to config rather than flag.

This approach seems preferable to flags, just as I already moved devel whitelist to be able to load from remote config. It means users do not need to know the right flag combination to run the tool, rather it just figures it out. This also means we can run same service with same options and same user on OBS which again seems preferable.