### PR TITLE
osclib/request_splitter: provide splitter-special-packages config variable.

### DIFF
--- a/osclib/request_splitter.py
+++ b/osclib/request_splitter.py
@@ -15,6 +15,9 @@ class RequestSplitter(object):
         # 55 minutes to avoid two staging bot loops of 30 minutes
         self.request_age_threshold = int(self.config.get('splitter-request-age-threshold', 55 * 60))
         self.staging_age_max = int(self.config.get('splitter-staging-age-max', 8 * 60 * 60))
+        special_packages= self.config.get('splitter-special-packages')
+        if special_packages:
+            StrategySpecial.PACKAGES = special_packages.split(' ')
 
         self.requests_ignored = self.api.get_ignored_requests()
 

--- a/osclib/request_splitter.py
+++ b/osclib/request_splitter.py
@@ -490,13 +490,10 @@ class StrategyQuick(StrategyNone):
 
 class StrategySpecial(StrategyNone):
     PACKAGES = [
-        'boost',
         'gcc',
-        'gcc6',
         'gcc7',
         'glibc',
         'kernel-source',
-        'util-linux',
     ]
 
     def apply(self, splitter):


### PR DESCRIPTION
- e8c27991568f69e7db699dfde0953914df01f9fe:
    osclib/request_splitter: reduce default list of special packages.

- c9743b5df0a7d48d4ece942c76a5a3c657c6e713:
    osclib/request_splitter: provide splitter-special-packages config variable.

@coolo Can thus be overridden by project config (like for Leap or SLE).

@DimStar77 The default reduction to special package list look already?