### PR TITLE
devel-project: utilize get_request_list(withfullhistory) param provided by osc 0.160.0.

### DIFF
--- a/dist/package/openSUSE-release-tools.spec
+++ b/dist/package/openSUSE-release-tools.spec
@@ -225,7 +225,8 @@ OSC plugin for cycle visualization, see `osc cycle --help`.
 Summary:        OSC plugin for the staging workflow
 Group:          Development/Tools/Other
 BuildArch:      noarch
-Requires:       osc >= 0.159.0
+# devel-project.py needs 0.160.0 for get_request_list(withfullhistory) param.
+Requires:       osc >= 0.160.0
 Requires:       osclib = %{version}
 
 %description -n osc-plugin-staging


### PR DESCRIPTION
The addition of queries to search() breaks the altered implementation of search. The custom search() can be dropped since openSUSE/osc@902b48f provides the missing functionality.

Fixes #1205.