### PR TITLE
travis: include all files instead of just osclib in coverage.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,7 @@ matrix:
         - pip install -r requirements.txt
         - pip install python-coveralls
       script:
-        - nosetests --with-coverage --cover-package=osclib --cover-inclusive
+        - nosetests --with-coverage --cover-package=. --cover-inclusive
       after_success:
         - coveralls
 


### PR DESCRIPTION
I always suspected based on percentage and change, but when working on #1207 I dug in when trying to get `check_source.py` to show up in report as covered. It's a bit interesting that no `--cover-package` argument will no result in what you would expect as documentation indicates current directory which one would assume is the same as `.`, but apparently not in nose land.

Makes sense to correct this before I finish up the fancy test PR so we can see the impact.

Summary: PITA + overly optimistic coverage reports.