### PR TITLE
osclib/conf: prefer already parsed conffile over OSC_CONFIG env variable.

### DIFF
--- a/osclib/conf.py
+++ b/osclib/conf.py
@@ -125,7 +125,7 @@ class Config(object):
     def __init__(self, project):
         self.project = project
 
-        conf_file = os.environ.get('OSC_CONFIG', '~/.oscrc')
+        conf_file = conf.config.get('conffile', os.environ.get('OSC_CONFIG', '~/.oscrc'))
         self.conf_file = os.path.expanduser(conf_file)
         self.remote_values = None
 

--- a/tests/obs.py
+++ b/tests/obs.py
@@ -135,7 +135,6 @@ class OBS(object):
         osc.core.conf.get_config(override_conffile=oscrc,
                                  override_no_keyring=True,
                                  override_no_gnome_keyring=True)
-        os.environ['OSC_CONFIG'] = oscrc
 
         # Internal status of OBS.  The mockup will use this data to
         # build the responses.  We will try to put responses as XML


### PR DESCRIPTION
This is consistent with expected behavior when using:
- osc.core.conf.get_config(override_conffile...)

Also removes the need to change the environment in OBS() which removes a leak.

Partial fix for #1214.