### PR TITLE
osc vdelreq: new command lists pending virtually accepted delete request status

### DIFF
--- a/dist/package/openSUSE-release-tools.spec
+++ b/dist/package/openSUSE-release-tools.spec
@@ -243,6 +243,15 @@ Requires:       osclib = %{version}
 %description -n osc-plugin-staging
 OSC plugin for the staging workflow, see `osc staging --help`.
 
+%package -n osc-plugin-vdelreq
+Summary:        OSC plugin to check for virtually accepted request
+Group:          Development/Tools/Other
+BuildArch:      noarch
+Requires:       osc >= 0.159.0
+
+%description -n osc-plugin-vdelreq
+OSC plugin to check for virtually accepted request, see `osc vdelreq --help`.
+
 %prep
 %setup -q
 
@@ -421,6 +430,7 @@ exit 0
 %exclude %{_datadir}/%{source_dir}/osc-check_dups.py
 %exclude %{_datadir}/%{source_dir}/osc-cycle.py
 %exclude %{_datadir}/%{source_dir}/osc-staging.py
+%exclude %{_datadir}/%{source_dir}/osc-vdelreq.py
 %exclude %{_datadir}/%{source_dir}/update_crawler.py
 %dir %{_sysconfdir}/openSUSE-release-tools
 
@@ -543,5 +553,10 @@ exit 0
 %defattr(-,root,root,-)
 %{_datadir}/%{source_dir}/osc-staging.py
 %{osc_plugin_dir}/osc-staging.py
+
+%files -n osc-plugin-vdelreq
+%defattr(-,root,root,-)
+%{_datadir}/%{source_dir}/osc-vdelreq.py
+%{osc_plugin_dir}/osc-vdelreq.py
 
 %changelog

--- a/osc-vdelreq.py
+++ b/osc-vdelreq.py
@@ -1,0 +1,103 @@
+#!/usr/bin/python
+# Copyright (c) 2017 SUSE LLC
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+from __future__ import print_function
+
+import os
+import os.path
+import sys
+
+from xml.etree import cElementTree as ET
+
+import osc.core
+import osc.conf
+
+from osc import cmdln
+from osc import oscerr
+
+def _has_binary(self, project, package):
+    query = {'view': 'binarylist', 'package': package, 'multibuild': '1'}
+    pkg_binarylist = ET.parse(osc.core.http_GET(osc.core.makeurl(self.apiurl, ['build', project, '_result'], query=query))).getroot()
+    for binary in pkg_binarylist.findall('./result/binarylist/binary'):
+        return 'Yes'
+    return 'No'
+
+
+def list_virtually_accepted_request(self, project, opts):
+    state_cond = "state/@name='review'+or+state/@name='revoked'+or+state/@name='revoked'"
+    if opts.all:
+        state_cond += "+or+state/@name='accepted'"
+    query = "match=({})+and+(action/target/@project='{}'+and+action/@type='delete')+and+"\
+            "((review/@state='new'+or+review/@state='accepted')+and+review/@by_group='{}')".format(state_cond, project, opts.delreq_review)
+    url = osc.core.makeurl(self.apiurl, ['search', 'request'], query)
+    f = osc.core.http_GET(url)
+    root = ET.parse(f).getroot()
+    rqs = []
+    for rq in root.findall('request'):
+        has_binary = 'No'
+        id = rq.attrib['id']
+        rq_state = rq.find('state').get('name')
+        pkg = rq.find('action/target').get('package')
+        if rq_state != 'accepted':
+            has_binary = self._has_binary(project, pkg)
+        for review in rq.findall('review'):
+            if review.get('by_group') and review.attrib['by_group'] == opts.delreq_review:
+                delreq_review_state = review.attrib['state']
+
+        content = {"id": int(id), "package": pkg, "rq_state": rq_state, "delreq_review_state": delreq_review_state, "has_binary": has_binary}
+        rqs.append(content)
+
+    rqs.sort(key=lambda d: d['id'])
+    for rq in rqs:
+        print("{} {} state is {} \n {} Virtually accept review is {} ( binary: {} )".format(str(rq['id']),
+            rq['package'], rq['rq_state'], "-".rjust(len(str(rq['id']))+1, ' '), rq['delreq_review_state'], rq['has_binary']))
+
+@cmdln.option('--delreq-review', dest='delreq_review', metavar='DELREQREVIEW', default='factory-maintainers',
+        help='the additional reviews')
+@cmdln.option('--all', action='store_true', default=False, help='shows all requests including accepted request')
+def do_vdelreq(self, subcmd, opts, *args):
+    """${cmd_name}: display pending virtual accept delete request
+
+    osc vdelreq [OPT] COMMAND PROJECT
+        Shows pending the virtual accept delete requests and the current state.
+
+    ${cmd_option_list}
+
+    "list" will list virtually accepted delete request.
+
+    Usage:
+        osc vdelreq [--delreq-review DELREQREVIEW] list PROJECT
+    """
+
+    self.apiurl = self.get_api_url()
+
+    if len(args) == 0:
+        raise oscerr.WrongArgs('No command given, see "osc help vdelreq"!')
+    if len(args) < 2:
+        raise oscerr.WrongArgs('No project given, see "osc help vdelreq"!')
+
+    cmd = args[0]
+    if cmd in ('list'):
+        self.list_virtually_accepted_request(args[1], opts)
+    else:
+        raise oscerr.WrongArgs('Unknown command: %s' % cmd)
+
+# vim: sw=4 et


### PR DESCRIPTION
<pre>
maxlin@tigercity:~/.osc-plugins $ osc vdelreq list openSUSE:Factory
536563 lxqt-common state is review 
       - Virtually accept review is new ( binary: Yes )

maxlin@tigercity:~/.osc-plugins $ osc vdelreq list --all openSUSE:Factory
527486 python-argparse state is accepted 
       - Virtually accept review is accepted ( binary: No )
528637 vlock state is accepted 
       - Virtually accept review is accepted ( binary: No )
529955 perl-CPAN-Meta state is accepted 
       - Virtually accept review is accepted ( binary: No )
529956 perl-CPAN-Meta-YAML state is accepted 
       - Virtually accept review is accepted ( binary: No )
530181 keybinder3 state is accepted 
       - Virtually accept review is accepted ( binary: No )
530703 perl-YAML-Perl state is accepted 
       - Virtually accept review is accepted ( binary: No )
530796 perl-PerlIO-eol state is accepted 
       - Virtually accept review is accepted ( binary: No )
530963 virtaal state is accepted 
       - Virtually accept review is accepted ( binary: No )
531141 mhtml-firefox state is accepted 
       - Virtually accept review is accepted ( binary: No )
531259 python3-jupyter_sphinx_theme state is accepted 
       - Virtually accept review is accepted ( binary: No )
531764 python3-PyWebDAV3-GNUHealth state is accepted 
       - Virtually accept review is accepted ( binary: No )
531766 python3-aiohttp state is accepted 
       - Virtually accept review is accepted ( binary: No )
531767 python3-minidb state is accepted 
       - Virtually accept review is accepted ( binary: No )
531768 python3-python3-openid state is accepted 
       - Virtually accept review is accepted ( binary: No )
531769 python3-websockets state is accepted 
       - Virtually accept review is accepted ( binary: No )
531871 python3-jupyter_ipython state is accepted 
       - Virtually accept review is accepted ( binary: No )
532337 gcc-java state is accepted 
       - Virtually accept review is accepted ( binary: No )
532338 gcc6 state is accepted 
       - Virtually accept review is accepted ( binary: No )
532339 java-1_5_0-gcj-compat state is accepted 
       - Virtually accept review is accepted ( binary: No )
532558 typo3-flow-1_1 state is accepted 
       - Virtually accept review is accepted ( binary: No )
532700 android-tools state is accepted 
       - Virtually accept review is accepted ( binary: No )
532729 pdftk state is accepted 
       - Virtually accept review is accepted ( binary: No )
532915 perl-Data-AMF state is accepted 
       - Virtually accept review is accepted ( binary: No )
533017 python3-WTForms state is accepted 
       - Virtually accept review is accepted ( binary: No )
533018 python3-Flask-WTF state is accepted 
       - Virtually accept review is accepted ( binary: No )
533424 gnome-mime-data state is accepted 
       - Virtually accept review is accepted ( binary: No )
533549 perl-Clipboard state is accepted 
       - Virtually accept review is accepted ( binary: No )
533959 PlotDigitizer state is accepted 
       - Virtually accept review is accepted ( binary: No )
534001 python-poppler-qt4 state is accepted 
       - Virtually accept review is accepted ( binary: No )
534126 s2tc state is accepted 
       - Virtually accept review is accepted ( binary: No )
534215 rubygem-minitest state is accepted 
       - Virtually accept review is accepted ( binary: No )
534252 python-puppetboard state is accepted 
       - Virtually accept review is accepted ( binary: No )
534253 python-pypuppetdb state is accepted 
       - Virtually accept review is accepted ( binary: No )
534254 rubygem-puppet state is accepted 
       - Virtually accept review is accepted ( binary: No )
534255 rubygem-puppet-lint state is accepted 
       - Virtually accept review is accepted ( binary: No )
534256 rubygem-puppet-syntax state is accepted 
       - Virtually accept review is accepted ( binary: No )
534257 rubygem-puppet_forge state is accepted 
       - Virtually accept review is accepted ( binary: No )
534258 rubygem-quixoten-puppetdb-terminus state is accepted 
       - Virtually accept review is accepted ( binary: No )
534259 rubygem-rspec-puppet state is accepted 
       - Virtually accept review is accepted ( binary: No )
534260 rubygem-semantic_puppet state is accepted 
       - Virtually accept review is accepted ( binary: No )
534261 rubygem-mcollective state is accepted 
       - Virtually accept review is accepted ( binary: No )
534262 rubygem-facter state is accepted 
       - Virtually accept review is accepted ( binary: No )
534263 rubygem-hiera state is accepted 
       - Virtually accept review is accepted ( binary: No )
534264 rubygem-hiera-eyaml state is accepted 
       - Virtually accept review is accepted ( binary: No )
534265 rubygem-hiera-eyaml-gpg state is accepted 
       - Virtually accept review is accepted ( binary: No )
534266 rubygem-r10k state is accepted 
       - Virtually accept review is accepted ( binary: No )
534267 rubygem-ra10ke state is accepted 
       - Virtually accept review is accepted ( binary: No )
534484 ghc-gtksourceview3 state is accepted 
       - Virtually accept review is accepted ( binary: No )
534622 perl-MooseX-Types-Parameterizable state is accepted 
       - Virtually accept review is accepted ( binary: No )
534952 gkrellm-cpufreq state is accepted 
       - Virtually accept review is accepted ( binary: No )
535178 q-tools state is accepted 
       - Virtually accept review is accepted ( binary: No )
535733 esound state is accepted 
       - Virtually accept review is accepted ( binary: No )
535779 ksshaskpass state is accepted 
       - Virtually accept review is accepted ( binary: No )
536040 rubygem-fast_gettext-1_1 state is accepted 
       - Virtually accept review is accepted ( binary: No )
536041 rubygem-cri-2_6 state is accepted 
       - Virtually accept review is accepted ( binary: No )
536042 rubygem-faraday_middleware-0_9 state is accepted 
       - Virtually accept review is accepted ( binary: No )
536065 pdfchain state is accepted 
       - Virtually accept review is accepted ( binary: No )
536563 lxqt-common state is review 
       - Virtually accept review is new ( binary: Yes )
</pre>

relating to https://github.com/openSUSE/osc-plugin-factory/issues/1164