### PR TITLE
 dist: provide metrics service and timer and install grafana dashboards.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ pkgdata_BINS = \
 	devel-project.py \
 	leaper.py \
 	manager_42.py \
+	metrics.py \
 	pkglistgen.sh \
 	repo_checker.py \
 	suppkg_rebuild.py \

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ VERSION = "build-$(shell date +%F)"
 all:
 
 install:
-	install -d -m 755 $(DESTDIR)$(bindir) $(DESTDIR)$(pkgdatadir) $(DESTDIR)$(unitdir) $(DESTDIR)$(oscplugindir) $(DESTDIR)$(sysconfdir)/$(package_name)
+	install -d -m 755 $(DESTDIR)$(bindir) $(DESTDIR)$(pkgdatadir) $(DESTDIR)$(unitdir) $(DESTDIR)$(oscplugindir) $(DESTDIR)$(sysconfdir)/$(package_name) $(DESTDIR)$(grafana_dashboards_dir)
 	for i in $(pkgdata_SCRIPTS); do install -m 755 $$i $(DESTDIR)$(pkgdatadir); done
 	chmod 644 $(DESTDIR)$(pkgdatadir)/osc-*.py
 	for i in $(pkgdata_DATA); do cp -a $$i $(DESTDIR)$(pkgdatadir); done
@@ -34,6 +34,7 @@ install:
 	for i in $(pkgdata_BINS); do ln -s $(pkgdatadir)/$$i $(DESTDIR)$(bindir)/osrt-$${i%.*}; done
 	install -m 755 script/* $(DESTDIR)$(bindir)
 	cp -R config/* $(DESTDIR)$(sysconfdir)/$(package_name)
+	for i in metrics/grafana/* ; do ln -s $(pkgdatadir)/$$i $(DESTDIR)$(grafana_dashboards_dir)/osrt-$$(basename $$i); done
 
 check: test
 

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,6 @@ pkgdata_BINS = \
 pkgdata_SCRIPTS=$(wildcard *.py *.pl *.sh)
 pkgdata_SCRIPTS+=bs_mirrorfull findfileconflicts
 pkgdata_DATA+=bs_copy metrics osclib $(wildcard *.pm *.testcase)
-package_name = openSUSE-release-tools
 VERSION = "build-$(shell date +%F)"
 
 all:

--- a/Makefile.common
+++ b/Makefile.common
@@ -5,6 +5,7 @@ datadir=$(prefix)/share
 sysconfdir=/etc
 unitdir=$(prefix)/lib/systemd/system
 pkgdatadir=$(datadir)/osc-plugin-factory
+grafana_dashboards_dir="/var/lib/grafana/dashboards/$(package_name)"
 oscplugindir=$(prefix)/lib/osc-plugins
 apachevhostsdir=$(sysconfdir)/apache2/vhosts.d
 tmpfilesdir=$(prefix)/lib/tmpfiles.d

--- a/Makefile.common
+++ b/Makefile.common
@@ -1,3 +1,4 @@
+package_name = openSUSE-release-tools
 prefix=/usr
 bindir=$(prefix)/bin
 datadir=$(prefix)/share

--- a/dist/package/openSUSE-release-tools.spec
+++ b/dist/package/openSUSE-release-tools.spec
@@ -151,6 +151,8 @@ Requires:       osclib = %{version}
 # TODO Requires: python-influxdb, but package does not exist in Factory, but
 # present in Cloud:OpenStack:Master/python-influxdb.
 Recommends:     python-influxdb
+Suggests:       grafana
+Suggests:       influxdb
 
 %description metrics
 Ingest relevant OBS and annotation data to generate insightful metrics.
@@ -268,6 +270,7 @@ make %{?_smp_mflags}
 
 %install
 %make_install \
+  grafana_dashboards_dir="%{_localstatedir}/lib/grafana/dashboards/%{name}" \
   oscplugindir="%{osc_plugin_dir}" \
   VERSION="%{version}"
 
@@ -340,6 +343,11 @@ exit 0
 %service_del_postun osrt-maintenance-incidents.service
 
 # TODO Provide metrics service once #1006 is resolved.
+%postun metrics
+# If grafana-server.service is enabled then restart it to load new dashboards.
+if [ -x /usr/bin/systemctl ] && systemctl is-enabled grafana-server ; then
+  /usr/bin/systemctl try-restart --no-block grafana-server
+fi
 
 %pre repo-checker
 %service_add_pre osrt-repo-checker.service

--- a/dist/package/openSUSE-release-tools.spec
+++ b/dist/package/openSUSE-release-tools.spec
@@ -148,7 +148,9 @@ Group:          Development/Tools/Other
 BuildArch:      noarch
 # TODO Update requirements.
 Requires:       osclib = %{version}
-# TODO Requires: python-influxdb, but package does not exist.
+# TODO Requires: python-influxdb, but package does not exist in Factory, but
+# present in Cloud:OpenStack:Master/python-influxdb.
+Recommends:     python-influxdb
 
 %description metrics
 Ingest relevant OBS and annotation data to generate insightful metrics.
@@ -489,6 +491,7 @@ exit 0
 
 %files metrics
 %defattr(-,root,root,-)
+%{_bindir}/osrt-metrics
 %{_datadir}/%{source_dir}/metrics
 %{_datadir}/%{source_dir}/metrics.py
 

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -23,7 +23,8 @@ issues are documented in:
 
 - InfluxDB instance
 - Grafana instance
-  - import `metrics/grafana` dashboards
+  - `grafana.ini`:
+    - `[dashboards.json].enabled = true` to use the dashboards provided by rpm
   - create data sources for desired projects
     setting name and database to the project name (ex. `openSUSE:Factory`)
 

--- a/systemd/osrt-metrics@.service
+++ b/systemd/osrt-metrics@.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=openSUSE Release Tools: metrics for %i
+
+[Service]
+Type=oneshot
+User=osrt-metrics
+SyslogIdentifier=osrt-metrics
+ExecStart=/usr/bin/osrt-metrics --debug -p "%i"
+TimeoutStartSec=8 hour
+
+[Install]
+WantedBy=multi-user.target

--- a/systemd/osrt-metrics@.timer
+++ b/systemd/osrt-metrics@.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=openSUSE Release Tools: metrics for %i
+
+[Timer]
+OnBootSec=120
+OnCalendar=daily
+Unit=osrt-metrics@%i.service
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
- a0c7dc362cd2670372c25b795ba25a0dede47bfe:
    dist: provide metrics service and timer.

- 10311c12c66d230cb57cf70eb4a7bc72f8d5e1d8:
    dist: install exported dashboards in grafana dashboard directory.

- 159790907e2f79c3586267b75a4a5ed65a7f6f7b:
    dist: include metrics.py in bindir.

- 02d5749d2835fdc1d24aed253bb6536ed2433456:
    dist: move package_name variable to Makefile.common.

Pre-requisite of #1170.