### PR TITLE
metrics: post deployment tweaks and fixes + opensuse-review-team who graphs

### DIFF
--- a/dist/package/openSUSE-release-tools.spec
+++ b/dist/package/openSUSE-release-tools.spec
@@ -509,7 +509,7 @@ exit 0
 %{_datadir}/%{source_dir}/metrics
 %{_datadir}/%{source_dir}/metrics.py
 # To avoid adding grafana as BuildRequires since it does not live in same repo.
-%dir %{_localstatedir}/lib/grafana
+%dir %attr(0750, grafana, grafana) %{_localstatedir}/lib/grafana
 %dir %{_localstatedir}/lib/grafana/dashboards
 %{_localstatedir}/lib/grafana/dashboards/%{name}
 %{_unitdir}/osrt-metrics@.service

--- a/dist/package/openSUSE-release-tools.spec
+++ b/dist/package/openSUSE-release-tools.spec
@@ -351,7 +351,7 @@ exit 0
 %postun metrics
 %systemd_postun
 # If grafana-server.service is enabled then restart it to load new dashboards.
-if [ -x /usr/bin/systemctl ] && systemctl is-enabled grafana-server ; then
+if [ -x /usr/bin/systemctl ] && /usr/bin/systemctl is-enabled grafana-server ; then
   /usr/bin/systemctl try-restart --no-block grafana-server
 fi
 

--- a/metrics.py
+++ b/metrics.py
@@ -18,6 +18,8 @@ from osclib.cache import Cache
 from osclib.conf import Config
 from osclib.stagingapi import StagingAPI
 
+SOURCE_DIR = os.path.dirname(os.path.realpath(__file__))
+
 # Duplicate Leap config to handle 13.2 without issue.
 osclib.conf.DEFAULT[
     r'openSUSE:(?P<project>[\d.]+)'] = osclib.conf.DEFAULT[
@@ -290,7 +292,7 @@ def walk_points(points, target):
 def ingest_release_schedule(project):
     points = []
     release_schedule = {}
-    release_schedule_file = 'metrics/annotation/{}.yaml'.format(project)
+    release_schedule_file = os.path.join(SOURCE_DIR, 'metrics/annotation/{}.yaml'.format(project))
     if project.endswith('Factory'):
         # Extract Factory "release schedule" from Tumbleweed snapshot list.
         command = 'rsync rsync.opensuse.org::opensuse-full/opensuse/tumbleweed/iso/Changes.* | ' \

--- a/metrics/grafana/compare.json
+++ b/metrics/grafana/compare.json
@@ -500,6 +500,6 @@
     ]
   },
   "timezone": "",
-  "title": "openSUSE Staging Comparison",
+  "title": "OSRT: Comparison",
   "version": 6
 }

--- a/metrics/grafana/review.json
+++ b/metrics/grafana/review.json
@@ -3,7 +3,7 @@
     "list": [
       {
         "datasource": "$project",
-        "enable": true,
+        "enable": false,
         "hide": false,
         "iconColor": "rgba(255, 96, 96, 1)",
         "limit": 100,

--- a/metrics/grafana/review.json
+++ b/metrics/grafana/review.json
@@ -1996,6 +1996,271 @@
       "showTitle": false,
       "title": "Dashboard Row",
       "titleSize": "h6"
+    },
+    {
+      "collapse": false,
+      "height": 250,
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "$project",
+          "fill": 1,
+          "id": 40,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "span": 12,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "alias": "$tag_who_completed",
+              "dsType": "influxdb",
+              "groupBy": [
+                {
+                  "params": [
+                    "$__interval"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "who_completed"
+                  ],
+                  "type": "tag"
+                },
+                {
+                  "params": [
+                    "null"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "measurement": "review",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "refId": "A",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "open_for"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "count"
+                  },
+                  {
+                    "params": [],
+                    "type": "cumulative_sum"
+                  }
+                ]
+              ],
+              "tags": [
+                {
+                  "key": "by_group",
+                  "operator": "=",
+                  "value": "opensuse-review-team"
+                }
+              ]
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "opensuse-review-team - who",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": false,
+      "title": "Dashboard Row",
+      "titleSize": "h6"
+    },
+    {
+      "collapse": false,
+      "height": 250,
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": true,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "$project",
+          "fill": 1,
+          "id": 41,
+          "interval": "1d",
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": false,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": true,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "span": 12,
+          "stack": true,
+          "steppedLine": false,
+          "targets": [
+            {
+              "alias": "$tag_who_completed",
+              "dsType": "influxdb",
+              "groupBy": [
+                {
+                  "params": [
+                    "$__interval"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "who_completed"
+                  ],
+                  "type": "tag"
+                },
+                {
+                  "params": [
+                    "null"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "measurement": "review",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "refId": "A",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "open_for"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "count"
+                  }
+                ]
+              ],
+              "tags": [
+                {
+                  "key": "by_group",
+                  "operator": "=",
+                  "value": "opensuse-review-team"
+                }
+              ]
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "opensuse-review-team - who",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": "100",
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": false,
+      "title": "Dashboard Row",
+      "titleSize": "h6"
     }
   ],
   "schemaVersion": 14,

--- a/metrics/grafana/review.json
+++ b/metrics/grafana/review.json
@@ -2005,8 +2005,8 @@
     "list": [
       {
         "current": {
-          "text": "openSUSE:Leap:42.3v2",
-          "value": "openSUSE:Leap:42.3v2"
+          "text": "openSUSE:Factory",
+          "value": "openSUSE:Factory"
         },
         "hide": 0,
         "label": null,

--- a/metrics/grafana/review.json
+++ b/metrics/grafana/review.json
@@ -2049,6 +2049,6 @@
     ]
   },
   "timezone": "",
-  "title": "openSUSE Staging Reviews",
+  "title": "OSRT: Reviews",
   "version": 12
 }

--- a/metrics/grafana/staging.json
+++ b/metrics/grafana/staging.json
@@ -3901,6 +3901,6 @@
     ]
   },
   "timezone": "",
-  "title": "Staging",
+  "title": "OSRT: Staging",
   "version": 20
 }

--- a/metrics/grafana/staging.json
+++ b/metrics/grafana/staging.json
@@ -372,7 +372,7 @@
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Project stats",
+          "title": "Totals",
           "tooltip": {
             "shared": true,
             "sort": 0,

--- a/metrics/grafana/staging.json
+++ b/metrics/grafana/staging.json
@@ -239,7 +239,7 @@
           "datasource": "$project",
           "fill": 1,
           "id": 1,
-          "interval": "1s",
+          "interval": null,
           "legend": {
             "alignAsTable": false,
             "avg": false,


### PR DESCRIPTION
- 9a6b483948b44602d612c54ea0b706f29a0d4bec:
    metrics/grafana/review: include opensuse-review-team who graphs.

- 586b177a97d9620646600ccd2688a297f5bb9e61:
    metrics/grafana/review: default to openSUSE:Factory.

- 736bfa235ea4060dbd5d9bda126ef7b228f67849:
    metrics/grafana/review: disable annotations by default.

- 6aafeba0c1d6f63fa9bfab5ac7998a554295a2e7:
    metrics/grafana/staging: "Project stats" to "Totals"

- 41c3c6948d9d0d8440121b9f78cc74023138ea85:
    metrics/grafana/staging: remove 1s interval as it causes RAM issues.

- c01a8a71ed2a5bc251315205eb3ae5eca6b1374a:
    metrics/grafana: standardize title prefix with 'OSRT: '.

- 0201a82722c2c73335081057bc9d3435651aa710:
    dist/ci: grafana dir must be owned by grafana user since it writes lock.

- dc74b8d0be10f9efcbf0bd19a490878479982744:
    dist/spec: correct metrics postun to reference systemctl by absolute path.

- d0c298246e56c0c02f68f0490f7b46dece084ce8:
    metrics: prefix release schedule file with source dir path.
    
    Otherwise, when deployed via package and run via /usr/bin the files are
    not found.

Fixes #1245.