### PR TITLE
metrics: reduce memory footprint by over 60%

### DIFF
--- a/metrics.py
+++ b/metrics.py
@@ -61,6 +61,8 @@ def search(apiurl, queries=None, **kwargs):
             # Stop paging once the expected number of items has been returned.
             break
 
+        # Release memory as otherwise ET seems to hold onto it.
+        collection.clear()
         queries['request']['offset'] += queries['request']['limit']
 
     _requests = requests


### PR DESCRIPTION
- d1b6125d4f2bfa1b2754d665dd331a4e50b8843a:
    metrics: rework to store points as named tuple and write in batches.
    
    Savings of around 400MB per 10,000 requests. Using a named tuple was the
    original approach for this reason, but the influxdb interface requires
    dict()s and it seemed silly to spend time converting them. Additionally,
    influxdb client already does batching.
    
    Unfortunately, with the amount of data processed for Factory that will
    continue to grow this approach is necessary. The dict() final structures
    are buffered up to ~1000 before being written and released. Another
    benefit of the batching is that influxdb does not allocate memory for the
    entire incoming batch.

- 6a2598779286d5b842bddd81f4a0e65ba61b1393:
    metrics: rework request pagination to provide as generator.
    
    This prevents the memory required to process to be enough to load all
    parsed request element trees at once. Instead only one page of requests
    is loaded at a time and the memory freed after processed. The end result
    is the memory consumption reduced by just over 20% (current Factory drops
    by around 2.5GB).

- 0de7fb839221d8d02877d4a606dc963b4e341ae4:
    metrics: call ET.clear() to release unneeded memory used by search result.
    
    Roughly 1800MB per 10,000 requests saved.

Without these changes the ingest process will not run on production machine even with 10GB of RAM. This drop the required memory from around 12GB to 4.5GB. The small batches also reduces the influxdb process overhead during writing. Interestingly, as noted in commit message above, one of the improvements was the original way I approached this, but changed to match influxdb interface. :( Additionally, the need to call `ElementTree.clear()` is rather odd. The combined effect of these changes should make 10GB more than enough RAM for several years to come at which point the incoming requests could potentially be partitioned or perhaps a RAM increase will be irrelevant.