### PR TITLE
Split EDITOR environment variable to handle flags in prefix.

### DIFF
--- a/issue-diff.py
+++ b/issue-diff.py
@@ -131,7 +131,7 @@ def prompt_interactive(changes, project, package):
         editor = os.getenv('EDITOR')
         if not editor:
             editor = 'xdg-open'
-        subprocess.call([editor, temp.name])
+        subprocess.call(editor.split(' ') + [temp.name])
 
         changes_after = yaml.safe_load(open(temp.name).read())
         if changes_after is None:

--- a/osc-staging.py
+++ b/osc-staging.py
@@ -599,7 +599,7 @@ def do_staging(self, subcmd, opts, *args):
                         editor = os.getenv('EDITOR')
                         if not editor:
                             editor = 'xdg-open'
-                        return_code = subprocess.call([editor, temp.name])
+                        return_code = subprocess.call(editor.split(' ') + [temp.name])
 
                         proposal = yaml.safe_load(open(temp.name).read())
 


### PR DESCRIPTION
Fixes #1271.

@fcrozat: if you have the time could you confirm? I tested with `cat -n`.