### PR TITLE
osclib/cycles: only cache target project build graph to avoid excessive cache.

### DIFF
--- a/osclib/cache.py
+++ b/osclib/cache.py
@@ -66,10 +66,13 @@ class Cache(object):
 
     CACHE_DIR = os.path.expanduser('~/.cache/osc-plugin-factory')
     TTL_LONG = 12 * 60 * 60
+    TTL_MEDIUM = 30 * 60
     TTL_SHORT = 5 * 60
     TTL_DUPLICATE = 3
     PATTERNS = {
         '/build/[^/]+/_result': TTL_DUPLICATE,
+        # For cycles when run via repo-checker cache non-stagings.
+        '/build/(?:[^/](?!:Staging:))+/[^/]+/[^/]+/_builddepinfo$': TTL_MEDIUM,
         # Group members cannot be guaranteed, but change rarely.
         '/group/[^/?]+$': TTL_SHORT,
         # Clear target project cache upon request acceptance.

--- a/osclib/cycle.py
+++ b/osclib/cycle.py
@@ -150,7 +150,6 @@ class CycleDetector(object):
         # Store packages prevoiusly ignored. Don't pollute the screen.
         self._ignore_packages = set()
 
-    @memoize(ttl=60*60*6)
     def _builddepinfo(self, project, repository, arch):
         root = None
         try:

--- a/osclib/cycle.py
+++ b/osclib/cycle.py
@@ -161,13 +161,6 @@ class CycleDetector(object):
             print('ERROR in URL %s [%s]' % (url, e))
         return root
 
-    def _get_builddepinfo(self, project, repository, arch, package):
-        """Get the builddep info for a single package"""
-        root = ET.fromstring(self._builddepinfo(project, repository, arch))
-        packages = [Package(element=e) for e in root.findall('package')]
-        package = [p for p in packages if p.pkg == package]
-        return package[0] if package else None
-
     def _get_builddepinfo_graph(self, project, repository, arch):
         """Generate the buildepinfo graph for a given architecture."""
 
@@ -209,12 +202,6 @@ class CycleDetector(object):
         # Store the subpkgs dict in the graph. It will be used later.
         graph.subpkgs = subpkgs
         return graph
-
-    def _get_builddepinfo_cycles(self, package, repository, arch):
-        """Generate the buildepinfo cycle list for a given architecture."""
-        root = ET.fromstring(self._builddepinfo(package, repository, arch))
-        return frozenset(frozenset(e.text for e in cycle.findall('package'))
-                         for cycle in root.findall('cycle'))
 
     def cycles(self, staging, project=None, repository='standard', arch='x86_64'):
         """Detect cycles in a specific repository."""


### PR DESCRIPTION
- 824fc98afd276befc345bc8be2c0ba2b05a0c251:
    osclib/cycles: only cache target project build graph to avoid excessive cache.

- 57d9d2986bf96cc104fc413707780a2ae12dddf9:
    osclib/cycles: drop _get_builddepinfo and _get_builddepinfo_cycles since unused.

Fixes #1265.