### PR TITLE
rebuildpacs: Ignore some more multibuild packages

### DIFF
--- a/rebuildpacs.pl
+++ b/rebuildpacs.pl
@@ -268,7 +268,7 @@ while (<INSTALLCHECK>) {
 
     s,^\s*,,;
     # patterns are too spammy and rebuilding doesn't help
-    next if (grep { $_ eq $cproblem } qw(patterns-openSUSE installation-images:Kubic));
+    next if (grep { $_ eq $cproblem } qw(patterns-openSUSE installation-images:Kubic fftw3:gnu-openmpi-hpc hdf5:mvapich2 hdf5:openmpi scalapack:gnu-mvapich2-hpc scalapack:gnu-openmpi-hpc python-numpy:gnu-hpc petsc:serial netcdf:serial netcdf:openmpi netcdf:gnu-hpc netcdf:gnu-openmpi-hpc netcdf:gnu-mvapich2-hpc));
     $problems{$cproblem}->{$_} = 1;
 
 }


### PR DESCRIPTION
Rebuildpacs has quite some issues when it comes to multibuild packages as
it can trigger packages over and over.

This works around the major pains for now, see https://github.com/openSUSE/osc-plugin-factory/issues/1222 for
more details.