### PR TITLE
Auto strip commas from the command

### DIFF
--- a/osc-cycle.py
+++ b/osc-cycle.py
@@ -33,6 +33,8 @@ def do_cycle(self, subcmd, opts, *args):
 
     print ("digraph depgraph {")
     for pkgname in args:
+        pkgname = pkgname.strip(',')
+        if len(pkgname) == 0: continue
         try:
             deps = ET.fromstring(get_dependson(apiurl, "openSUSE:Factory", "standard", "x86_64", [pkgname]))
 


### PR DESCRIPTION
This allows the user to simply copy a list from OBS' webui, which happens to be comma-separeted, without having to manually modify the list, saving another minute of tedious work