### PR TITLE
fcc_submitter: handle multibuild package in build_succeeded package list

### DIFF
--- a/fcc_submitter.py
+++ b/fcc_submitter.py
@@ -184,10 +184,25 @@ class FccSubmitter(object):
         root = ET.fromstring(''.join(f))
         #print ET.dump(root)
 
+        failed_multibuild_pacs = []
         pacs = []
         for node in root.findall('result'):
             if node.get('repository') == 'pure_42' and node.get('arch') == 'x86_64':
                 for pacnode in node.findall('status'):
+                    if ':' in pacnode.get('package'):
+                        mainpac = pacnode.get('package').split(':')[0]
+                        if pacnode.get('code') not in ['succeeded', 'excluded']:
+                            failed_multibuild_pacs.append(pacnode.get('package'))
+                            if mainpac not in failed_multibuild_pacs:
+                                failed_multibuild_pacs.append(mainpac)
+                            if mainpac in pacs:
+                                pacs.remove(mainpac)
+                        else:
+                            if mainpac in failed_multibuild_pacs:
+                                failed_multibuild_pacs.append(pacnode.get('package'))
+                            elif mainpac not in pacs:
+                                pacs.append(mainpac)
+                        continue
                     if pacnode.get('code') == 'succeeded':
                         pacs.append(pacnode.get('package'))
             else:


### PR DESCRIPTION
Do not add multibuild flavor package to the list, only main package should lists in the pacakge list, also make sure all flavor under multibuild pacakge are build succeded otheriwse drop the main package from the list.

For example:

    <status package="lua-lua-dbus" code="excluded" />
    <status package="lua-lua-dbus:lua51" code="unresolvable">
    <details>nothing provides lua51-ldbus</details>
    </status>
    <status package="lua-lua-dbus:lua53" code="unresolvable">
    <details>nothing provides lua53-ldbus</details>
    </status>

would not be added to the list, the case below is going to be added,

    <status package="lua-ldbus" code="excluded" />
    <status package="lua-ldbus:lua51" code="succeeded" />
    <status package="lua-ldbus:lua53" code="succeeded" />



