### PR TITLE
repo_checker: only update comment if published or message changed.

### DIFF
--- a/osclib/comments.py
+++ b/osclib/comments.py
@@ -123,6 +123,12 @@ class CommentAPI(object):
         marker = '<!-- {}{} -->'.format(bot, ' ' + ' '.join(infos) if info else '')
         return marker + '\n\n' + comment
 
+    def remove_marker(self, comment):
+        if comment.startswith('<!--'):
+            comment = ''.join(comment.splitlines(True)[1:]).strip()
+
+        return comment
+
     def add_comment(self, request_id=None, project_name=None,
                     package_name=None, comment=None, parent_id=None):
         """Add a comment in an object in OBS.


### PR DESCRIPTION
In effect, only update comment when either:

- target project is published and build hash has changed
- comment changed

Best of both worlds presumably.

Changes the identical comment comparison to first strip the comment marker before comparing text to allow for non-identical `info_extra` to be present in comments that are compared.

Still some edge-cases for long-running cases where state changes during/before review, but at most a second comment might result for one project.

In the process of testing more extensively.

Fixes #1296.