### PR TITLE
osclib/conf: allow devel projects to utilize tools that require conf.

### DIFF
--- a/osclib/conf.py
+++ b/osclib/conf.py
@@ -109,6 +109,24 @@ DEFAULT = {
         'delreq-review': None,
         'main-repo': 'standard',
     },
+    # Allows devel projects to utilize tools that require config, but not
+    # complete StagingAPI support.
+    r'(?P<project>.*$)': {
+        'staging': '%(project)s', # Allows for dashboard/config if desired.
+        'staging-group': None,
+        'staging-archs': '',
+        'staging-dvd-archs': '',
+        'rings': None,
+        'nonfree': None,
+        'rebuild': None,
+        'product': None,
+        'openqa': None,
+        'lock': None,
+        'lock-ns': None,
+        'delreq-review': None,
+        'main-repo': 'openSUSE_Factory',
+        'remote-config': False,
+    },
 }
 
 #


### PR DESCRIPTION
Originally, my thought was to add the flags back and take them as defaults if unable to load project config, but that would require the continued use of that pattern for all `ReviewBots`. `repo-checker` already has a pending issue to support devel projects (#1210) and makes use if this config in the same manor. It seems more useful to allow the config to work for non-openSUSE/SUSE projects. Obviously, `StagingAPI` will not work for them, but the config and local overrides should. Additionally, `remote-config` could work if a project decided to add a `dashboard` container, but not something I am worried about at the moment.

Tested using the following.

```
./check_source.py --osc-debug --debug --dry id 539170
# X11:Deepin/cogl@3 -> GNOME:Factory/cogl
```

The `gnome-review-bot.service` on `packagelists` should be changed:

```diff
- ExecStart=/usr/local/bin/check_source --ignore-devel --skip-add-reviews review
+ ExecStart=/usr/local/bin/check_source review
```

Optionally, `--skip-add-reviews` can remain, but all the individual reviews are disabled since no values are provided in config.