### PR TITLE
check_source: load target project config during check_action_delete().

### DIFF
--- a/check_source.py
+++ b/check_source.py
@@ -218,6 +218,8 @@ class CheckSource(ReviewBot.ReviewBot):
         return False
 
     def check_action_delete(self, request, action):
+        self.target_project_config(action.tgt_project)
+
         if action.tgt_repository is not None:
             if action.tgt_project.startswith('openSUSE:'):
                 self.review_messages['declined'] = 'The repositories in the openSUSE:* namespace ' \


### PR DESCRIPTION
Otherwise, causes fatal crash trying to access self.repo_checker.

Confirmed crash and fix after be running.

```
./check_source.py --osc-debug --debug --dry id 561280
```

Fixes #1204.