### PR TITLE
osclib/conf: order config defaults by priority and allow devel projects to utilize.

### DIFF
--- a/osclib/conf.py
+++ b/osclib/conf.py
@@ -15,6 +15,7 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 from ConfigParser import ConfigParser
+from collections import OrderedDict
 import io
 import os
 import operator
@@ -108,6 +109,7 @@ DEFAULT = {
         'remote-config': False,
         'delreq-review': None,
         'main-repo': 'standard',
+        'priority': 100, # Lower than SLE-15 since less specific.
     },
 }
 
@@ -144,7 +146,8 @@ class Config(object):
     def populate_conf(self):
         """Add sane default into the configuration."""
         defaults = {}
-        for prj_pattern in DEFAULT:
+        default_ordered = OrderedDict(sorted(DEFAULT.items(), key=lambda i: i[1].get('priority', 99)))
+        for prj_pattern in default_ordered:
             match = re.match(prj_pattern, self.project)
             if match:
                 project = match.group('project')

--- a/osclib/conf.py
+++ b/osclib/conf.py
@@ -111,6 +111,25 @@ DEFAULT = {
         'main-repo': 'standard',
         'priority': 100, # Lower than SLE-15 since less specific.
     },
+    # Allows devel projects to utilize tools that require config, but not
+    # complete StagingAPI support.
+    r'(?P<project>.*$)': {
+        'staging': '%(project)s', # Allows for dashboard/config if desired.
+        'staging-group': None,
+        'staging-archs': '',
+        'staging-dvd-archs': '',
+        'rings': None,
+        'nonfree': None,
+        'rebuild': None,
+        'product': None,
+        'openqa': None,
+        'lock': None,
+        'lock-ns': None,
+        'delreq-review': None,
+        'main-repo': 'openSUSE_Factory',
+        'remote-config': False,
+        'priority': 1000, # Lowest priority as only a fallback.
+    },
 }
 
 #

--- a/tests/config_tests.py
+++ b/tests/config_tests.py
@@ -45,6 +45,7 @@ class TestConfig(unittest.TestCase):
             'openSUSE:Leap:15.0',
             'SUSE:SLE-15:GA',
             'SUSE:SLE-12:GA',
+            'GNOME:Factory',
         )
 
         # Ensure each pattern is match instead of catch-all pattern.

--- a/tests/config_tests.py
+++ b/tests/config_tests.py
@@ -1,5 +1,6 @@
 import unittest
 from osc import conf
+from osclib.conf import DEFAULT
 from osclib.conf import Config
 from osclib.stagingapi import StagingAPI
 
@@ -32,3 +33,24 @@ class TestConfig(unittest.TestCase):
         self.config.apply_remote(self.api)
         # Ensure blank file not overridden.
         self.assertEqual(self.obs.dashboard_counts['config'], 1)
+
+    def test_pattern_order(self):
+        # Add pattern to defaults in order to identify which was matched.
+        for pattern in DEFAULT:
+            DEFAULT[pattern]['pattern'] = pattern
+
+        # A list of projects that should match each of the DEFAULT patterns.
+        projects = (
+            'openSUSE:Factory',
+            'openSUSE:Leap:15.0',
+            'SUSE:SLE-15:GA',
+            'SUSE:SLE-12:GA',
+        )
+
+        # Ensure each pattern is match instead of catch-all pattern.
+        patterns = set()
+        for project in projects:
+            config = Config(project)
+            patterns.add(conf.config[project]['pattern'])
+
+        self.assertEqual(len(patterns), len(DEFAULT))


### PR DESCRIPTION
- 61c83500d3ca8a21b772fc1100437411a8643a71:
    osclib/conf: allow devel projects to utilize tools that require conf.

- 865750258cd853dc4d69f42b307522cf58b76891:
    osclib/conf: order config defaults by priority.
    
    Ensures that less specific patterns do not overtake more specific patterns
    by allowing for priority based ordering.

Followup to #1321 which was reverted due to catch-all pattern being ordered before SLE. The lack of ordering is pre-existing, but luckily not encountered. I went ahead and added an optional `priority` key to allow for clear sorting. This could also be done by defining the defaults using `OrderedDict`, but this seems preferable.

I added a lower priority to the general (older) SLE config since it would gobble up SLE-15 if mis-ordered. Included a test while at it. :)