### PR TITLE
pkglistgen: migrate bash scripts to python followup

### DIFF
--- a/osclib/conf.py
+++ b/osclib/conf.py
@@ -71,7 +71,7 @@ DEFAULT = {
         'repo-checker': 'repo-checker',
         'pkglistgen-archs': 'x86_64',
         'pkglistgen-archs-ports': 'aarch64',
-        'pkglistgen-locals-from': 'openSUSE-product',
+        'pkglistgen-locals-from': 'openSUSE.product',
         'pkglistgen-include-suggested': '1',
         'pkglistgen-delete-kiwis': 'openSUSE-ftp-ftp-x86_64.kiwi openSUSE-cd-mini-x86_64.kiwi',
     },

--- a/pkglistgen.py
+++ b/pkglistgen.py
@@ -1020,6 +1020,8 @@ class CommandLineInterface(ToolBase.CommandLineInterface):
 
     def update_and_solve_target(self, apiurl, target_project, target_config, main_repo, opts,
                                 skip_release=False):
+        print('[{}] {}/{}: update and solve'.format(opts.scope, opts.project, main_repo))
+
         group = target_config.get('pkglistgen-group', '000package-groups')
         product = target_config.get('pkglistgen-product', '000product')
         release = target_config.get('pkglistgen-release', '000release-packages')
@@ -1076,8 +1078,10 @@ class CommandLineInterface(ToolBase.CommandLineInterface):
         self.options.output_dir = product_dir
         self.postoptparse()
 
+        print('-> do_update')
         self.do_update('update', opts)
 
+        print('-> do_solve')
         opts.ignore_unresolvable = bool(target_config.get('pkglistgen-ignore-unresolvable'))
         opts.ignore_recommended = bool(target_config.get('pkglistgen-ignore-recommended'))
         opts.include_suggested = bool(target_config.get('pkglistgen-include-suggested'))
@@ -1088,6 +1092,7 @@ class CommandLineInterface(ToolBase.CommandLineInterface):
         delete_products = target_config.get('pkglistgen-delete-products', '').split(' ')
         self.unlink_list(product_dir, delete_products)
 
+        print('-> product service')
         for product_file in glob.glob(os.path.join(product_dir, '*.product')):
             print(subprocess.check_output(
                 [PRODUCT_SERVICE, product_file, product_dir, opts.project]))

--- a/pkglistgen.py
+++ b/pkglistgen.py
@@ -1027,7 +1027,8 @@ class CommandLineInterface(ToolBase.CommandLineInterface):
         url = makeurl(apiurl, ['source', opts.project])
         packages = ET.parse(http_GET(url)).getroot()
         if packages.find('entry[@name="{}"]'.format(product)) is None:
-            undelete_package(apiurl, opts.project, product, 'revive')
+            if not self.options.dry:
+                undelete_package(apiurl, opts.project, product, 'revive')
             # TODO disable build.
             print('{} undeleted, skip dvd until next cycle'.format(product))
             return
@@ -1043,7 +1044,8 @@ class CommandLineInterface(ToolBase.CommandLineInterface):
             checkout_list.append(release)
 
             if packages.find('entry[@name="{}"]'.format(release)) is None:
-                undelete_package(apiurl, opts.project, product, 'revive')
+                if not self.options.dry:
+                    undelete_package(apiurl, opts.project, product, 'revive')
                 print('{} undeleted, skip dvd until next cycle'.format(release))
                 return
 

--- a/pkglistgen.py
+++ b/pkglistgen.py
@@ -1070,6 +1070,7 @@ class CommandLineInterface(ToolBase.CommandLineInterface):
                                      ['supportstatus.txt', 'groups.yml', 'package-groups.changes'])
         self.change_extension(product_dir, '.spec.in', '.spec')
 
+        self.options.input_dir = group_dir
         self.options.output_dir = product_dir
         self.postoptparse()
 

--- a/pkglistgen.py
+++ b/pkglistgen.py
@@ -1076,8 +1076,10 @@ class CommandLineInterface(ToolBase.CommandLineInterface):
 
         self.do_update('update', opts)
 
-        opts.ignore_recommended = bool(target_config.get('pkglistgen-include-recommended'))
+        opts.ignore_unresolvable = bool(target_config.get('pkglistgen-ignore-unresolvable'))
+        opts.ignore_recommended = bool(target_config.get('pkglistgen-ignore-recommended'))
         opts.include_suggested = bool(target_config.get('pkglistgen-include-suggested'))
+        opts.locale = target_config.get('pkglistgen-local')
         opts.locales_from = target_config.get('pkglistgen-locals-from')
         self.do_solve('solve', opts)
 

--- a/systemd/osrt-pkglistgen@.service
+++ b/systemd/osrt-pkglistgen@.service
@@ -3,7 +3,7 @@ Description=openSUSE Release Tools: generate package lists for %i
 
 [Service]
 User=osrt-repo-checker
-ExecStart=/usr/bin/osrt-pkglistgen -p "%i"
+ExecStart=/usr/bin/osrt-pkglistgen update_and_solve -p "%i"
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
As indicated in #1312, I had not yet performed a complete run so it was not clear everything worked. The following as tweaks needed to fix some minor issues and added `--dry` handling for `undelete_package()` from wrappers. One interesting bit is `LOCALES_FROM` was set to `openSUSE-product`, but as far as I can tell either this was not trickled all the way down or should have been `openSUSE.product` (period instead of dash) [@lnussel thoughts?]. Also added config mapping for remaining flags which is likely main bit needed for SLE.

Still completing a full run locally before updating tortuga.

- ce650ffbdbf15e1ef62fea746b49c29fcbd63391:
    pkglistgen: update_and_solve: include step in output for debugging.

- 407a802fec8ae64ade1e3ac761bf16b7351e34c5:
    pkglistgen: update_and_solve: handle --dry for undelete_package().

- 16fa9618ecf9ae50f99edf7ec9feb8711a231e6f:
    pkglistgen: update_and_solve: include ignore_unresolvable and local options for solve.

- 8892c0d8214202afd6c27b3c4d76b77c66411876:
    pkglistgen: update_and_solve: set input_dir to group_dir for solve.

- c06050ab89df801b5b898fcffa8e3baa81dcf029:
    osclib/conf: correct Leap 15.0 default locales-from from - to . product.

- e1b85fd00c3fca5e65445c529df921c827ef3b01:
    systemd/pkglistgen: add update_and_solve subcommand.
  