### PR TITLE
pkglistgen: post deployment spec requirement and bug fixes

### DIFF
--- a/dist/package/openSUSE-release-tools.spec
+++ b/dist/package/openSUSE-release-tools.spec
@@ -60,6 +60,8 @@ Requires:       python-PyYAML
 Requires:       python-cmdln
 Requires:       python-colorama
 Requires:       python-lxml
+# issue-diff.py, legal-auto.py, and openqa-maintenance.py
+Requires:       python-requests
 Requires:       python-pycurl
 Requires:       python-python-dateutil
 Requires:       python-pyxdg
@@ -203,6 +205,7 @@ Group:          Development/Tools/Other
 BuildArch:      noarch
 Requires:       osclib = %{version}
 Requires:       obs-service-product_converter
+Requires:       python-requests
 Requires:       python-solv
 # we use the same user as repo-checker
 PreReq:         openSUSE-release-tools-repo-checker

--- a/dist/package/openSUSE-release-tools.spec
+++ b/dist/package/openSUSE-release-tools.spec
@@ -371,6 +371,7 @@ fi
 %exclude %{_datadir}/%{source_dir}/manager_42.py
 %exclude %{_datadir}/%{source_dir}/metrics
 %exclude %{_datadir}/%{source_dir}/metrics.py
+%exclude %{_datadir}/%{source_dir}/pkglistgen.py
 %exclude %{_datadir}/%{source_dir}/repo_checker.pl
 %exclude %{_datadir}/%{source_dir}/repo_checker.py
 %exclude %{_datadir}/%{source_dir}/suppkg_rebuild.py
@@ -486,6 +487,7 @@ fi
 %files pkglistgen
 %defattr(-,root,root,-)
 %{_bindir}/osrt-pkglistgen
+%{_datadir}/%{source_dir}/pkglistgen.py
 %{_unitdir}/osrt-pkglistgen@.service
 %{_unitdir}/osrt-pkglistgen@.timer
 

--- a/pkglistgen.py
+++ b/pkglistgen.py
@@ -63,6 +63,7 @@ from osclib.memoize import CACHEDIR
 
 logger = logging.getLogger()
 
+SCRIPT_PATH = os.path.dirname(os.path.realpath(__file__))
 ARCHITECTURES = ['x86_64', 'ppc64le', 's390x', 'aarch64']
 DEFAULT_REPOS = ("openSUSE:Factory/standard")
 PRODUCT_SERVICE = '/usr/lib/obs/service/create_single_product'
@@ -717,7 +718,7 @@ class CommandLineInterface(ToolBase.CommandLineInterface):
         """
 
         # only there to parse the repos
-        bs_mirrorfull = os.path.join(os.path.dirname(__file__), 'bs_mirrorfull')
+        bs_mirrorfull = os.path.join(SCRIPT_PATH, 'bs_mirrorfull')
         global_update = False
         for prp in self.tool.repos:
             project, repo = prp.split('/')

--- a/pkglistgen.py
+++ b/pkglistgen.py
@@ -1012,7 +1012,7 @@ class CommandLineInterface(ToolBase.CommandLineInterface):
                 # DVD project first since it depends on main.
                 if api.rings:
                     opts_dvd = copy.deepcopy(opts)
-                    opts.project += ':DVD'
+                    opts_dvd.project += ':DVD'
                     self.options.repos.insert(0, '/'.join([opts.project, main_repo]))
                     self.update_and_solve_target(apiurl, target_project, target_config, main_repo, opts_dvd, skip_release=True)
 


### PR DESCRIPTION
- ba07d6b51271bee7b8d2da07490898f9c50da13c:
    pkglistgen: do_update_and_solve: staging correct :DVD subproject append.

- cf2b591c09622949dc852ebd22f64967d90e7c0c:
    pkglistgen: first pass __file__ through realpath due to packaging symlink.
    
    Same setup as repo-checker.py rather than what worked due to wrapper
    scripts.

- 80f46a2d5d7b4f87c7f356184258b82cd8799903:
    dist/spec: move pkglistgen.py under subpackage ownership.

- 5a2d955dfb4099a52e873e2daaf669bebc72e87d:
    dist/spec: add python-requests requirement were applicable.