### PR TITLE
dist/spec: license: s/and/AND/ to follow standard.

### DIFF
--- a/dist/package/openSUSE-release-tools.spec
+++ b/dist/package/openSUSE-release-tools.spec
@@ -23,7 +23,7 @@ Name:           openSUSE-release-tools
 Version:        0
 Release:        0
 Summary:        Tools to aid in staging and release work for openSUSE/SUSE
-License:        GPL-2.0+ and MIT
+License:        GPL-2.0+ AND MIT
 Group:          Development/Tools/Other
 Url:            https://github.com/openSUSE/osc-plugin-factory
 Source:         %{name}-%{version}.tar.xz


### PR DESCRIPTION
After discussing #1322 it would seem best to fix our own case.