### PR TITLE
systemd/metrics: change service to be non-incremental and weekly.

### DIFF
--- a/metrics.py
+++ b/metrics.py
@@ -349,6 +349,8 @@ def main(args):
 
     # Use separate cache since it is persistent.
     Cache.CACHE_DIR = os.path.expanduser('~/.cache/osc-plugin-factory-metrics')
+    if args.wipe_cache:
+        Cache.delete_all()
     Cache.PATTERNS['/search/request'] = sys.maxint
     Cache.init()
 
@@ -378,6 +380,7 @@ if __name__ == '__main__':
     parser.add_argument('--port', default=8086, help='InfluxDB post')
     parser.add_argument('--user', default='root', help='InfluxDB user')
     parser.add_argument('--password', default='root', help='InfluxDB password')
+    parser.add_argument('--wipe-cache', action='store_true', help='wipe GET request cache before executing')
     args = parser.parse_args()
 
     sys.exit(main(args))

--- a/systemd/osrt-metrics@.service
+++ b/systemd/osrt-metrics@.service
@@ -4,7 +4,9 @@ Description=openSUSE Release Tools: metrics for %i
 [Service]
 User=osrt-metrics
 SyslogIdentifier=osrt-metrics
-ExecStart=/usr/bin/osrt-metrics --debug -p "%i"
+# TODO #1244: improve incremental data ingest
+# ExecStart=/usr/bin/osrt-metrics --debug -p "%i"
+ExecStart=/usr/bin/osrt-metrics --debug -p "%i" --wipe-cache
 
 [Install]
 WantedBy=multi-user.target

--- a/systemd/osrt-metrics@.timer
+++ b/systemd/osrt-metrics@.timer
@@ -3,7 +3,9 @@ Description=openSUSE Release Tools: metrics for %i
 
 [Timer]
 OnBootSec=120
-OnCalendar=daily
+# TODO #1244: improve incremental data ingest
+# OnCalendar=daily
+OnCalendar=weekly
 Unit=osrt-metrics@%i.service
 
 [Install]


### PR DESCRIPTION
Until OBS exposes the sort field via API as referenced in #1244 incremental ingest is not possible. As such fallback to full ingest once weekly instead of completely disabled at the movement.

Presumably the data amount will not be an issue once weekly.