### PR TITLE
osclib/request_splitter: allow special packages to be empty.

### DIFF
--- a/osclib/request_splitter.py
+++ b/osclib/request_splitter.py
@@ -16,7 +16,7 @@ class RequestSplitter(object):
         self.request_age_threshold = int(self.config.get('splitter-request-age-threshold', 55 * 60))
         self.staging_age_max = int(self.config.get('splitter-staging-age-max', 8 * 60 * 60))
         special_packages= self.config.get('splitter-special-packages')
-        if special_packages:
+        if special_packages is not None:
             StrategySpecial.PACKAGES = special_packages.split(' ')
 
         self.requests_ignored = self.api.get_ignored_requests()
@@ -480,6 +480,7 @@ class StrategyQuick(StrategyNone):
         splitter.filter_add('not(./review[not(@by_user="leaper" or @by_group="factory-staging")])')
 
 class StrategySpecial(StrategyNone):
+    # Configurable via splitter-special-packages.
     PACKAGES = [
         'gcc',
         'gcc7',


### PR DESCRIPTION
@lnussel I added this variable override a while back, but seems we forgot about it since you asked in IRC the other day. Given it sounds like you would like no special packages for Leap I updated code to handle empty string variable override.

I'll go ahead and update project config for Leap 15.0 to set the special list to empty, but feel free to update.