### PR TITLE
fcc_submitter: fix a regression from previous commit

### DIFF
--- a/fcc_submitter.py
+++ b/fcc_submitter.py
@@ -255,7 +255,7 @@ class FccSubmitter(object):
         root = ET.fromstring(http_GET(url).read())
         data = {}
         linkinfo = root.find('linkinfo')
-        if linkinfo:
+        if linkinfo is not None:
             data['linkinfo'] = linkinfo.attrib['package']
         else:
             data['linkinfo'] = None


### PR DESCRIPTION
There is a previous commit causes fcc_submitter does not store linkinfo package information to data list, this causes fcc_submitter fails to find the main-package information.

Regression from https://github.com/openSUSE/osc-plugin-factory/commit/62f50d267fd1f6e5c2a78ac88dda9bd305900cdf#diff-f7f109926d6b387e4ab4b2488a47bd13