### PR TITLE
ttm: change Leap 15 product path in current_version

### DIFF
--- a/totest-manager.py
+++ b/totest-manager.py
@@ -724,6 +724,8 @@ class ToTest150(ToTestBaseNew):
     def get_current_snapshot(self):
         return self.iso_build_version(self.project + ':ToTest', self.main_products[0])
 
+    def current_version(self):
+        return self.iso_build_version(self.project, self.main_products[1])
 
 class ToTest150Ports(ToTestBaseNew):
     main_products = [


### PR DESCRIPTION
There is no openSUSE-cd-mini-x86_64 in Leap 15 main project's 000product, it
was only exist in :ToTest sub-project.