### PR TITLE
pkglistgen: delete kiwis by scope

### DIFF
--- a/osclib/conf.py
+++ b/osclib/conf.py
@@ -74,7 +74,8 @@ DEFAULT = {
         'pkglistgen-archs-ports': 'aarch64',
         'pkglistgen-locales-from': 'openSUSE.product',
         'pkglistgen-include-suggested': '1',
-        'pkglistgen-delete-kiwis': 'openSUSE-ftp-ftp-x86_64.kiwi openSUSE-cd-mini-x86_64.kiwi',
+        'pkglistgen-delete-kiwis-rings': 'openSUSE-ftp-ftp-x86_64.kiwi openSUSE-cd-mini-x86_64.kiwi',
+        'pkglistgen-delete-kiwis-staging': 'openSUSE-ftp-ftp-x86_64.kiwi openSUSE-cd-mini-x86_64.kiwi',
     },
     r'SUSE:(?P<project>SLE-15.*$)': {
         'staging': 'SUSE:%(project)s:Staging',

--- a/pkglistgen.py
+++ b/pkglistgen.py
@@ -1099,7 +1099,7 @@ class CommandLineInterface(ToolBase.CommandLineInterface):
             print(subprocess.check_output(
                 [PRODUCT_SERVICE, product_file, product_dir, opts.project]))
 
-        delete_kiwis = target_config.get('pkglistgen-delete-kiwis', '').split(' ')
+        delete_kiwis = target_config.get('pkglistgen-delete-kiwis-{}'.format(opts.scope), '').split(' ')
         self.unlink_list(product_dir, delete_kiwis)
 
         spec_files = glob.glob(os.path.join(product_dir, '*.spec'))


### PR DESCRIPTION
Replace config option pkglistgen-delete-kiwis by
pkglistgen-delete-kiwis-$scope. The main project needs all kiwis while
in Rings and Stagings we don't want the ftp tree for example.