### PR TITLE
dist/ci/docker-compose-obs: print osc output on timeout for debugging.

### DIFF
--- a/dist/ci/docker-compose-obs
+++ b/dist/ci/docker-compose-obs
@@ -43,6 +43,11 @@ fi
 
 until $osc -q -A local api /about 2> /dev/null ; do
   echo "waiting for OBS to be responsive..."
-  ((c++)) && ((c==60)) && docker-compose logs && exit 1
+  # Print osc output incase of failure and container logs for debugging.
+  ((c++)) && ((c==60)) && (
+    docker-compose logs
+    $osc -q -A local api /about
+    exit 1
+  )
   sleep 1
 done


### PR DESCRIPTION
To aid in future debugging of `osc` failures as seen in #1361.