### PR TITLE
osclib/accept: print todo from staging config after completion.

### DIFF
--- a/osc-staging.py
+++ b/osc-staging.py
@@ -192,6 +192,7 @@ def do_staging(self, subcmd, opts, *args):
         The keys that may be set in staging configuration are:
 
         - repo_checker-binary-whitelist[-arch]: appended to target project list
+        - todo: text to be printed after staging is accepted
 
     "cleanup_rings" will try to cleanup rings content and print
         out problems

--- a/osclib/accept_command.py
+++ b/osclib/accept_command.py
@@ -6,6 +6,7 @@ from xml.etree import cElementTree as ET
 from osc.core import change_request_state, show_package_meta, wipebinaries
 from osc.core import http_GET, http_PUT, http_DELETE, http_POST
 from osc.core import delete_package, search, set_devel_project
+from osclib.config_command import ConfigCommand
 from datetime import date
 
 
@@ -144,6 +145,7 @@ class AcceptCommand(object):
 
         self.api.accept_status_comment(project, packages)
         self.api.staging_deactivate(project)
+        ConfigCommand(self.api).perform([project], 'todo')
 
         return True
 


### PR DESCRIPTION
I went for the simplest implementation, just `todo` key. If this ends up being heavily used in such a way that it makes sense to support `todo*` or similar then adding something like `--add` support to `config` command where that adds incremental `todo` keys and reads them back with `todo*` then it can be added to accept as well.

For now this seems sufficient. I went ahead and ran the following for `Leap:15.0`.

```
osc staging config C todo something
```

So this can be tested in production when C is accepted. Otherwise I tested the added code manually outside of `accept` command. The result should be the follow after the normal output.

```
todo = something
```

Fixes #1324.