### PR TITLE
create_test_dvds: do not lock vim-data

### DIFF
--- a/create_test_Factory_dvd-1.testcase
+++ b/create_test_Factory_dvd-1.testcase
@@ -49,5 +49,4 @@ job lock name patterns-openSUSE-x11_opt
 job lock name patterns-base-x11_opt
 job lock name readline-doc
 job lock name SuSEfirewall2
-job lock name vim-data
 job lock name gettext-runtime-mini


### PR DESCRIPTION
vim now requires vim-data instead of recommends.

was in packagelists vm already.