### PR TITLE
Handling for NonFree: splits NonFree request to a own group always

### DIFF
--- a/osclib/adi_command.py
+++ b/osclib/adi_command.py
@@ -87,9 +87,13 @@ class AdiCommand:
             print(Fore.YELLOW + (group if group != '' else 'wanted') + Fore.RESET)
 
             name = None
+            nonfree_repo_required = False
             for request in splitter.grouped[group]['requests']:
                 request_id = int(request.get('id'))
                 target_package = request.find('./action/target').get('package')
+                target_project = request.find('./action/target').get('project')
+                if self.api.cnonfree and self.api.cnonfree == target_project:
+                    nonfree_repo_required = True
                 line = '- {} {}{:<30}{}'.format(request_id, Fore.CYAN, target_package, Fore.RESET)
 
                 message = self.api.ignore_format(request_id)
@@ -108,7 +112,7 @@ class AdiCommand:
                 if name is None:
                     use_frozenlinks = group in source_projects_expand and not split
                     name = self.api.create_adi_project(None,
-                            use_frozenlinks, group)
+                            use_frozenlinks, group, nonfree_repo_required)
 
                 if not self.api.rq_to_prj(request_id, name):
                     return False

--- a/osclib/request_splitter.py
+++ b/osclib/request_splitter.py
@@ -115,6 +115,8 @@ class RequestSplitter(object):
         target_project = target.get('project')
         target_package = target.get('package')
         devel, _ = devel_project_fallback(self.api.apiurl, target_project, target_package)
+        if self.api.cnonfree and self.api.cnonfree == target_project:
+            devel = 'NonFree'
         if not devel and request_type == 'submit':
             devel = request.find('./action/source').get('project')
         if devel:

--- a/osclib/stagingapi.py
+++ b/osclib/stagingapi.py
@@ -1739,7 +1739,7 @@ class StagingAPI(object):
         l = ET.tostring(flink)
         http_PUT(url, data=l)
 
-    def create_adi_project(self, name, use_frozenlinks=False, src_prj=None):
+    def create_adi_project(self, name, use_frozenlinks=False, src_prj=None, nonfree_repo_required=False):
         """Create an ADI project."""
         if not name:
             name = self._candidate_adi_project()
@@ -1757,6 +1757,11 @@ class StagingAPI(object):
             linkproject = ''
             repository = '<repository name="standard">'
 
+        if nonfree_repo_required:
+            nonfree_repo = "<path project=\"{}\" repository=\"standard\"/>".format(self.cnonfree)
+        else:
+            nonfree_repo = ''
+
         meta = """
         <project name="{0}">
           <title></title>
@@ -1770,12 +1775,13 @@ class StagingAPI(object):
             <enable/>
           </debuginfo>
           {4}
+            {6}
             <path project="{5}" repository="standard"/>
             <path project="{1}" repository="standard"/>
             <arch>x86_64</arch>
           </repository>
         </project>""".format(name, self.project, self.extract_adi_number(name), linkproject, repository,
-                             self.cstaging)
+                             self.cstaging, nonfree_repo)
 
         url = make_meta_url('prj', name, self.apiurl)
         http_PUT(url, data=meta)


### PR DESCRIPTION
Splits NonFree request to a own group always and enable :NonFree project build
in meta.