### PR TITLE
adi: place :NonFree requests in separate adi with :NonFree path.

### DIFF
--- a/osclib/adi_command.py
+++ b/osclib/adi_command.py
@@ -81,6 +81,9 @@ class AdiCommand:
                 splitter.group_by('./action/target/@devel_project')
             else:
                 splitter.group_by('./action/source/@project')
+
+            if not split:
+                splitter.group_by('./action/target/@nonfree')
         splitter.split()
 
         for group in sorted(splitter.grouped.keys()):
@@ -89,7 +92,8 @@ class AdiCommand:
             name = None
             for request in splitter.grouped[group]['requests']:
                 request_id = int(request.get('id'))
-                target_package = request.find('./action/target').get('package')
+                target = request.find('./action/target')
+                target_package = target.get('package')
                 line = '- {} {}{:<30}{}'.format(request_id, Fore.CYAN, target_package, Fore.RESET)
 
                 message = self.api.ignore_format(request_id)
@@ -107,8 +111,9 @@ class AdiCommand:
                 # request is processed from a particular group.
                 if name is None:
                     use_frozenlinks = group in source_projects_expand and not split
+                    nonfree = bool(target.get('nonfree'))
                     name = self.api.create_adi_project(None,
-                            use_frozenlinks, group)
+                            use_frozenlinks, group, nonfree)
 
                 if not self.api.rq_to_prj(request_id, name):
                     return False

--- a/osclib/request_splitter.py
+++ b/osclib/request_splitter.py
@@ -121,6 +121,9 @@ class RequestSplitter(object):
             target.set('devel_project', devel)
             StrategySuper.supplement(request)
 
+        if target_project == self.api.cnonfree:
+            target.set('nonfree', 'nonfree')
+
         ring = self.ring_get(target_package)
         if ring:
             target.set('ring', ring)

--- a/osclib/stagingapi.py
+++ b/osclib/stagingapi.py
@@ -1739,7 +1739,7 @@ class StagingAPI(object):
         l = ET.tostring(flink)
         http_PUT(url, data=l)
 
-    def create_adi_project(self, name, use_frozenlinks=False, src_prj=None):
+    def create_adi_project(self, name, use_frozenlinks=False, src_prj=None, nonfree=False):
         """Create an ADI project."""
         if not name:
             name = self._candidate_adi_project()
@@ -1757,6 +1757,11 @@ class StagingAPI(object):
             linkproject = ''
             repository = '<repository name="standard">'
 
+        if nonfree:
+            nonfree_path = "<path project=\"{}\" repository=\"standard\"/>".format(self.cnonfree)
+        else:
+            nonfree_path = ''
+
         meta = """
         <project name="{0}">
           <title></title>
@@ -1770,12 +1775,13 @@ class StagingAPI(object):
             <enable/>
           </debuginfo>
           {4}
+            {6}
             <path project="{5}" repository="standard"/>
             <path project="{1}" repository="standard"/>
             <arch>x86_64</arch>
           </repository>
         </project>""".format(name, self.project, self.extract_adi_number(name), linkproject, repository,
-                             self.cstaging)
+                             self.cstaging, nonfree_path)
 
         url = make_meta_url('prj', name, self.apiurl)
         http_PUT(url, data=meta)


### PR DESCRIPTION
Refactored version of #1378 that allows for two level grouping to maintain splitting by devel project first. End result is groups like the following, where you can have two groups for same devel project.

- Archiving
- devel:libraries:c_c++
- devel:tools:building
- **network:telephony**
- **network:telephony__nonfree**
- openSUSE:Factory
- systemsmanagement:wbem