### PR TITLE
CreatePackageDescr: ignore debuginfo.build deps for i-i-debuginfodeps…

### DIFF
--- a/CreatePackageDescr.pm
+++ b/CreatePackageDescr.pm
@@ -127,10 +127,7 @@ sub package_snippet($) {
             && $prv eq "/usr/bin/mplayer" );
         next if ( $prv eq "this-is-only-for-build-envs" );
         next
-          if ( $name eq "installation-images-debuginfodeps"
-            && $prv =~ m/debuginfo.build/ );
-        next
-          if ( $name eq "installation-images-debuginfodeps-openSUSE"
+          if ( $name =~ "^installation-images-debuginfodeps.*"
             && $prv =~ m/debuginfo.build/ );
         $out .= "$prv\n";
     }


### PR DESCRIPTION
…-Kubic

All -debuginfo dependencies are split to other repos, and are not able to be
tested here. Allow repo-checker to skip over those.