### PR TITLE
pkglistgen: integrate drop list creation into update_and_solve and project family methods

### DIFF
--- a/osclib/conf.py
+++ b/osclib/conf.py
@@ -180,6 +180,8 @@ class Config(object):
                         defaults[k] = v % {'project': project}
                     elif isinstance(v, basestring) and '%(project.lower)s' in v:
                         defaults[k] = v % {'project.lower': project.lower()}
+                    elif isinstance(v, basestring) and '%(version)s' in v:
+                        defaults[k] = v % {'version': match.group('version')}
                     else:
                         defaults[k] = v
                 break

--- a/osclib/conf.py
+++ b/osclib/conf.py
@@ -52,6 +52,7 @@ DEFAULT = {
         'devel-project-enforce': 'True',
         'review-team': 'opensuse-review-team',
         'repo-checker': 'repo-checker',
+        'pkglistgen-product-family-include': 'openSUSE:Leap:N',
     },
     r'openSUSE:(?P<project>Leap:(?P<version>[\d.]+))': {
         'staging': 'openSUSE:%(project)s:Staging',

--- a/osclib/conf.py
+++ b/osclib/conf.py
@@ -47,12 +47,13 @@ DEFAULT = {
         'lock-ns': 'openSUSE',
         'delreq-review': 'factory-maintainers',
         'main-repo': 'standard',
+        'download-baseurl': 'http://download.opensuse.org/tumbleweed/',
         # check_source.py
         'devel-project-enforce': 'True',
         'review-team': 'opensuse-review-team',
         'repo-checker': 'repo-checker',
     },
-    r'openSUSE:(?P<project>Leap:[\d.]+)': {
+    r'openSUSE:(?P<project>Leap:(?P<version>[\d.]+))': {
         'staging': 'openSUSE:%(project)s:Staging',
         'staging-group': 'factory-staging',
         'staging-archs': 'i586 x86_64',
@@ -67,6 +68,7 @@ DEFAULT = {
         'lock-ns': 'openSUSE',
         'delreq-review': None,
         'main-repo': 'standard',
+        'download-baseurl': 'http://download.opensuse.org/distribution/leap/%(version)s/',
         # check_source.py
         # review-team optionally added by leaper.py.
         'repo-checker': 'repo-checker',

--- a/osclib/core.py
+++ b/osclib/core.py
@@ -3,6 +3,7 @@ from datetime import datetime
 from dateutil.parser import parse as date_parse
 import re
 from xml.etree import cElementTree as ET
+from lxml import etree as ETL
 from urllib2 import HTTPError
 
 from osc.core import get_binarylist
@@ -173,3 +174,10 @@ def request_age(request):
         created = request.find('history').get('when')
     created = date_parse(created)
     return datetime.utcnow() - created
+
+def project_list_prefix(apiurl, prefix):
+    """Get a list of project with the same prefix."""
+    query = {'match': 'starts-with(@name, "{}")'.format(prefix)}
+    url = makeurl(apiurl, ['search', 'project', 'id'], query)
+    root = ETL.parse(http_GET(url)).getroot()
+    return root.xpath('project/@name')

--- a/osclib/stagingapi.py
+++ b/osclib/stagingapi.py
@@ -49,6 +49,7 @@ from osc.core import streamfile
 
 from osclib.cache import Cache
 from osclib.core import devel_project_get
+from osclib.core import project_list_prefix
 from osclib.comments import CommentAPI
 from osclib.ignore_command import IgnoreCommand
 from osclib.memoize import memoize
@@ -333,17 +334,10 @@ class StagingAPI(object):
         :return list of known staging projects
         """
 
-        projects = []
+        projects = project_list_prefix(self.apiurl, self.cstaging + ':')
+        if not include_dvd:
+            projects = filter(lambda p: not p.endswith(':DVD'), projects)
 
-        query = "id?match=starts-with(@name,'{}:')".format(self.cstaging)
-        url = self.makeurl(['search', 'project', query])
-        projxml = http_GET(url)
-        root = ET.parse(projxml).getroot()
-        for val in root.findall('project'):
-            project = val.get('name')
-            if not include_dvd and project.endswith(':DVD'):
-                continue
-            projects.append(project)
         return projects
 
     def extract_staging_short(self, p):

--- a/osclib/util.py
+++ b/osclib/util.py
@@ -1,0 +1,78 @@
+from osclib.core import project_list_prefix
+
+
+def project_list_family(apiurl, project):
+    """
+    Determine the available projects within the same product family.
+
+    Skips < SLE-12 due to format change.
+    """
+    if project == 'openSUSE:Factory':
+        return [project]
+
+    count_original = project.count(':')
+    if project.startswith('SUSE:SLE'):
+        project = ':'.join(project.split(':')[:2])
+        family_filter = lambda p: p.endswith(':GA') and not p.startswith('SUSE:SLE-11')
+    else:
+        family_filter = lambda p: p.count(':') == count_original
+
+    prefix = ':'.join(project.split(':')[:-1])
+    projects = project_list_prefix(apiurl, prefix)
+
+    return filter(family_filter, projects)
+
+def project_list_family_prior(apiurl, project, include_self=False):
+    """
+    Determine the available projects within the same product family released
+    prior to the specified project.
+    """
+    projects = project_list_family(apiurl, project)
+    past = False
+    prior = []
+    for entry in sorted(projects, key=project_list_family_sorter, reverse=True):
+        if entry == project:
+            past = True
+            if not include_self:
+                continue
+
+        if past:
+            prior.append(entry)
+
+    return prior
+
+def project_list_family_sorter(project):
+    """Extract key to be used as sorter (oldest to newest)."""
+    version = project_version(project)
+
+    if version >= 42:
+        version -= 42
+
+    if project.endswith(':Update'):
+        version += 0.01
+
+    return version
+
+def project_version(project):
+    """
+    Extract a float representation of the project version.
+
+    For example:
+    - openSUSE:Leap:15.0 -> 15.0
+    - openSUSE:Leap:42.3 -> 42.3
+    - SUSE:SLE-15:GA     -> 15.0
+    - SUSE:SLE-15-SP1:GA -> 15.1
+    """
+    if ':Leap:' in project:
+        return float(project.split(':')[2])
+
+    if ':SLE-' in project:
+        version = project.split(':')[1]
+        parts = version.split('-')
+        version = float(parts[1])
+        if len(parts) > 2:
+            # Add each service pack as a tenth.
+            version += float(parts[2][2:]) / 10
+        return version
+
+    return None

--- a/pkglistgen.py
+++ b/pkglistgen.py
@@ -837,11 +837,16 @@ class CommandLineInterface(ToolBase.CommandLineInterface):
                 # mark it explicitly to avoid having 2 pools while GC is not run
                 del pool
 
+        ofh = sys.stdout
+        if self.options.output_dir:
+            name = os.path.join(self.options.output_dir, 'obsoletepackages.inc')
+            ofh = open(name, 'w')
+
         for reponame in sorted(set(drops.values())):
-            print("<!-- %s -->" % reponame)
+            print("<!-- %s -->" % reponame, file=ofh)
             for p in sorted(drops):
                 if drops[p] != reponame: continue
-                print("  <obsoletepackage>%s</obsoletepackage>" % p)
+                print("  <obsoletepackage>%s</obsoletepackage>" % p, file=ofh)
 
     @cmdln.option('--overwrite', action='store_true', help='overwrite if output file exists')
     def do_dump_solv(self, subcmd, opts, baseurl):

--- a/pkglistgen.py
+++ b/pkglistgen.py
@@ -854,6 +854,9 @@ class CommandLineInterface(ToolBase.CommandLineInterface):
     def do_dump_solv(self, subcmd, opts, baseurl):
         """${cmd_name}: fetch repomd and dump solv
 
+        Dumps solv from published repository. Use solve to generate from
+        pre-published repository.
+
         If an output directory is specified, a file named according
         to the build is created there. Otherwise the solv file is
         dumped to stdout.
@@ -929,6 +932,9 @@ class CommandLineInterface(ToolBase.CommandLineInterface):
     @cmdln.option('--locales-from', metavar='FILE', help='get supported locales from product file FILE')
     def do_solve(self, subcmd, opts):
         """${cmd_name}: Solve groups
+
+        Generates solv from pre-published repository contained in local cache.
+        Use dump_solv to extract solv from published repository.
 
         ${cmd_usage}
         ${cmd_option_list}

--- a/tests/obs.py
+++ b/tests/obs.py
@@ -19,6 +19,7 @@ import os
 import re
 import string
 import time
+import urllib
 import urllib2
 import urlparse
 import xml.etree.cElementTree as ET
@@ -810,7 +811,8 @@ class OBS(object):
     @GET('/search/project/id')
     def search_project_id(self, request, uri, headers):
         """Return a search result /search/project/id."""
-        assert urlparse.urlparse(uri).query == "match=starts-with(@name,'openSUSE:Factory:Staging:')"
+        assert urlparse.urlparse(uri).query == urllib.urlencode(
+            {'match': 'starts-with(@name, "openSUSE:Factory:Staging:")'})
 
         response = (404, headers, '<result>Not found</result>')
         try:

--- a/tests/util_tests.py
+++ b/tests/util_tests.py
@@ -1,0 +1,81 @@
+from osclib.util import project_list_family
+from osclib.util import project_list_family_prior
+from osclib.util import project_list_family_sorter
+from osclib.util import project_list_prefix
+from osclib import util
+import unittest
+
+
+class TestUtil(unittest.TestCase):
+    def setUp(self):
+        util._project_list_prefix = util.project_list_prefix
+
+        def project_list_prefix_replacement(apiurl, prefix):
+            if prefix == 'openSUSE:Leap':
+                return [
+                    'openSUSE:Leap:15.0',
+                    'openSUSE:Leap:15.0:Update',
+                    'openSUSE:Leap:15.0:NonFree',
+                    'openSUSE:Leap:15.0:NonFree:Update',
+                    'openSUSE:Leap:42.2',
+                    'openSUSE:Leap:42.3',
+                    'openSUSE:Leap:42.3:Update',
+                    'openSUSE:Leap:42.3:NonFree',
+                    'openSUSE:Leap:42.3:NonFree:Update',
+                ]
+            elif prefix == 'SUSE':
+                return [
+                    'SUSE:SLE-10',
+                    'SUSE:SLE-10:SP2',
+                    'SUSE:SLE-11',
+                    'SUSE:SLE-11:GA',
+                    'SUSE:SLE-11:SP1',
+                    'SUSE:SLE-11:SP1:Update',
+                    'SUSE:SLE-12:GA',
+                    'SUSE:SLE-12-SP1:GA',
+                    'SUSE:SLE-12-SP1:Update',
+                    'SUSE:SLE-15:GA',
+                ]
+
+            return []
+
+        util.project_list_prefix = project_list_prefix_replacement
+
+    def tearDown(self):
+        util.project_list_prefix = util._project_list_prefix
+
+    def test_project_list_family(self):
+        self.assertEqual(project_list_family(None, 'openSUSE:Factory'), ['openSUSE:Factory'])
+
+        expected = ['openSUSE:Leap:15.0', 'openSUSE:Leap:42.2', 'openSUSE:Leap:42.3']
+        self.assertEqual(expected, project_list_family(None, 'openSUSE:Leap:15.0'))
+        self.assertEqual(expected, project_list_family(None, 'openSUSE:Leap:42.3'))
+
+        expected = ['SUSE:SLE-12:GA', 'SUSE:SLE-12-SP1:GA', 'SUSE:SLE-15:GA']
+        self.assertEqual(expected, project_list_family(None, 'SUSE:SLE-15:GA'))
+        self.assertEqual(expected, project_list_family(None, 'SUSE:SLE-15-SP1:GA'))
+
+    def test_project_list_family_sorter(self):
+        projects = sorted(project_list_family(None, 'openSUSE:Leap:15.0'), key=project_list_family_sorter)
+        self.assertEqual(projects[0], 'openSUSE:Leap:42.2')
+        self.assertEqual(projects[2], 'openSUSE:Leap:15.0')
+
+        projects = sorted(project_list_family(None, 'SUSE:SLE-15:GA'), key=project_list_family_sorter)
+        self.assertEqual(projects[0], 'SUSE:SLE-12:GA')
+        self.assertEqual(projects[2], 'SUSE:SLE-15:GA')
+
+    def test_project_list_family_prior(self):
+        projects = project_list_family_prior(None, 'openSUSE:Leap:15.0', include_self=True)
+        self.assertEqual(projects, ['openSUSE:Leap:15.0', 'openSUSE:Leap:42.3', 'openSUSE:Leap:42.2'])
+
+        projects = project_list_family_prior(None, 'openSUSE:Leap:15.0')
+        self.assertEqual(projects, ['openSUSE:Leap:42.3', 'openSUSE:Leap:42.2'])
+
+        projects = project_list_family_prior(None, 'openSUSE:Leap:42.3')
+        self.assertEqual(projects, ['openSUSE:Leap:42.2'])
+
+        projects = project_list_family_prior(None, 'SUSE:SLE-15:GA')
+        self.assertEqual(projects, ['SUSE:SLE-12-SP1:GA', 'SUSE:SLE-12:GA'])
+
+        projects = project_list_family_prior(None, 'SUSE:SLE-12-SP1:GA')
+        self.assertEqual(projects, ['SUSE:SLE-12:GA'])


### PR DESCRIPTION
- dc3b9e15e126e40c71757f544c504dec95ed7051:
    osclib/conf: include Leap for Factory during pkglistgen.

- c56c23f14808880e60bca633acba1428e20fbbdd:
    pkglistgen: include some hints about the difference between solv files.

- b58cb89641a7a23ebae3a5150c2c79efd1333014:
    **pkglistgen: integrate drop list creation into update_and_solve.**
    
    In order to generate a complete drop list the nonfree repository must also
    be cached for both current and published builds. The solv files are then
    merged and used to generate drop list.

- 5e35baac618bac8b106d0afc567360d51a976950:
    pkglistgen: do_dump_solv(): handle old-style product repo format.
    
    This allows for generating solv cache for Leap versions prior to 15.0
    which avoids the need to have them checked into git like previous
    package-lists repository.

- 0590162cc300a71fecd46de24918a4f939720d88:
    pkglistgen: do_create_droplist(): print to file when output_dir available.

- 4d98ff86c42171326108395b1b471784adb4a231:
    pkglistgen: provide do_update_merge() to combine free and nonfree solv.

- 9e77f2ccbccea77ea981e7e950f11a3ddab0e4a7:
    osclib/util: provide project_list_family* and project_version().

- 378470e8c9ece5d4d42754baa8c281ff8303b1a0:
    osclib/stagingapi: get_staging_projects(): utilize project_list_prefix().

- 42e698ec340513b4322cd25447c4b5d4efda032f:
    osclib/core: provide project_list_prefix().

- 5aa70e15466dfb30113adfe03410bc760d85de71:
    osclib/conf: add download-baseurl for Leap and Factory.

- 3f8cf29542e5f0d49378d51acad6e1a1881c347e:
    osclib/conf: support version in project pattern as value replacement.

The product family functions should be usable in `leaper.py` to avoid all the hard-coding and priority orders and projects that has to be updated each cycle.

Rather than checking `solv` files into git like `package-lists` this code creates `solv` files for the relevant products in the family in a local cache. Unless I am missing something there seems to be no reason to keep them in git since they can be re-created. As discussed in #1375 they can be sync'd somewhere for backup if desired (as perhaps _Tumbleweed_ may desire to keep all snapshots just in case). Then again, we can re-create them for at least the last three months from my _Tumbleweed Snapshots_ ;).

Locally, the following exist after running for _Leap 15.0_.

```
~/.cache/opensuse-packagelists/solv/
~/.cache/opensuse-packagelists/solv/openSUSE:Leap:42.2
~/.cache/opensuse-packagelists/solv/openSUSE:Leap:42.2/openSUSE-Addon-NonOss-FTP-x86_64-Build0073.solv
~/.cache/opensuse-packagelists/solv/openSUSE:Leap:42.2/openSUSE-42.2-x86_64-Build0283.merged.solv
~/.cache/opensuse-packagelists/solv/openSUSE:Leap:42.2/openSUSE-42.2-x86_64-Build0283.solv
~/.cache/opensuse-packagelists/solv/openSUSE:Leap:42.3
~/.cache/opensuse-packagelists/solv/openSUSE:Leap:42.3/openSUSE-Addon-NonOss-FTP-x86_64-Build0082.solv
~/.cache/opensuse-packagelists/solv/openSUSE:Leap:42.3/openSUSE-42.3-x86_64-Build0331.solv
~/.cache/opensuse-packagelists/solv/openSUSE:Leap:42.3/openSUSE-42.3-x86_64-Build0331.merged.solv
~/.cache/opensuse-packagelists/solv/openSUSE:Leap:15.0
~/.cache/opensuse-packagelists/solv/openSUSE:Leap:15.0/openSUSE-15.0-x86_64-Build115.1.solv
~/.cache/opensuse-packagelists/solv/openSUSE:Leap:15.0/openSUSE-Leap-15.0-Addon-NonOss-FTP-x86_64-Build115.1.solv
~/.cache/opensuse-packagelists/solv/openSUSE:Leap:15.0/openSUSE-15.0-x86_64-Build115.1.merged.solv
~/.cache/opensuse-packagelists/solv/openSUSE:Leap:42.1
~/.cache/opensuse-packagelists/solv/openSUSE:Leap:42.1/openSUSE-42.1-x86_64-Build0265.solv
~/.cache/opensuse-packagelists/solv/openSUSE:Leap:42.1/openSUSE-Addon-NonOss-FTP-i586-x86_64-Build0039.solv
~/.cache/opensuse-packagelists/solv/openSUSE:Leap:42.1/openSUSE-42.1-x86_64-Build0265.merged.solv
```

`mergesolv` seems to create a `solv` file that is smaller than the size of the two source `solv` files. I haven't verified if that makes sense, but performing the same operation as `package-lists` version. I noticed that `steamcmd` is show as removed when it exists in Leap 15.0, but did not investigate further.

Once deployed the `obsoletepackages.inc` in `000package-groups` should be dropped to avoid confusion as this will generate one in `000product` each run.

In general the command line classes should be thin glue code that maps command line arguments to function calls instead of contain the bulk of code. With this and my previous PR to migrate wrapper scripts into `pkglistgen.py` it is ever more clear the misuse of the `ToolBase.CommandLineInterface` class. Since a variety of methods within that class need to be called by higher level wrapper methods they should be separated to allow for all arguments to be passed directly. Having everything in _CLI_ class results in the awquardness of having to rerun `setup_tool()` multiple times to change global arguments (like `repos`) and copy/pass around `opts`, not to mention `subcmd` (ie. `do_thing('thing', ...)`). For example see the extremely small `repo_checker` _CLI_ class.

https://github.com/openSUSE/osc-plugin-factory/blob/cd1fa5db15f01317f9a1c9893380e17d42122fc0/repo_checker.py#L500-L529

Fixes #1375.