### PR TITLE
 osclib/conf: leap: incorporate proven settings for future releases.

### DIFF
--- a/osclib/conf.py
+++ b/osclib/conf.py
@@ -70,6 +70,10 @@ DEFAULT = {
         # check_source.py
         # review-team optionally added by leaper.py.
         'repo-checker': 'repo-checker',
+        # 16 hour staging window for follow-ups since lower throughput.
+        'splitter-staging-age-max': '57600',
+        # No special packages since they will pass through SLE first.
+        'splitter-special-packages': '',
         'pkglistgen-archs': 'x86_64',
         'pkglistgen-archs-ports': 'aarch64',
         'pkglistgen-locales-from': 'openSUSE.product',

--- a/osclib/conf.py
+++ b/osclib/conf.py
@@ -74,6 +74,10 @@ DEFAULT = {
         'splitter-staging-age-max': '57600',
         # No special packages since they will pass through SLE first.
         'splitter-special-packages': '',
+        # Allow `unselect --cleanup` to operate immediately on:
+        # - Update crawler requests (leaper)
+        # - F-C-C submitter requests (maxlin_factory)
+        'unselect-cleanup-whitelist': 'leaper maxlin_factory',
         'pkglistgen-archs': 'x86_64',
         'pkglistgen-archs-ports': 'aarch64',
         'pkglistgen-locales-from': 'openSUSE.product',


### PR DESCRIPTION
Taken from [remote config](https://build.opensuse.org/package/view_file/openSUSE:Leap:15.0:Staging/dashboard/config) these are settings used for `42.3` and now `15.0` and seem to work well so rather than have to copy to future remote configs might as well make them defaults.

Leaving `splitter-whitelist` out since future Leap may or may not have non-whitelisted and they can change like _Factory_.