### PR TITLE
remove Leap 42.2 from tests

### DIFF
--- a/data/incidents.json
+++ b/data/incidents.json
@@ -109,13 +109,6 @@
       "DISTRI" : "sle",
       "ARCH" : "x86_64"
    },
-   "openSUSE:Leap:42.2:Update" : {
-      "DISTRI" : "opensuse",
-      "ARCH" : "x86_64",
-      "ISO" : "openSUSE-Leap-42.2-DVD-x86_64.iso",
-      "FLAVOR" : "Maintenance",
-      "VERSION" : "42.2"
-   },
    "SUSE:Updates:SLE-SERVER:12-SP2:x86_64" : {
       "VERSION" : "12-SP2",
       "FLAVOR" : "Server-DVD-Incidents",

--- a/data/repos.json
+++ b/data/repos.json
@@ -1,27 +1,5 @@
 {
   "https://openqa.opensuse.org": {
-    "openSUSE:Leap:42.2:Update": {
-      "repos": [
-        "http://download.opensuse.org/update/leap/42.2-test/", 
-        "http://download.opensuse.org/update/leap/42.2/oss/", 
-        "http://download.opensuse.org/update/leap/42.2/non-oss/"
-      ], 
-      "settings": [
-        {
-          "ARCH": "x86_64", 
-          "DISTRI": "opensuse", 
-          "FLAVOR": "UpdateTest", 
-          "VERSION": "42.2"
-        }, 
-        {
-          "ARCH": "x86_64", 
-          "DISTRI": "opensuse", 
-          "FLAVOR": "Updates", 
-          "VERSION": "42.2"
-        }
-      ], 
-      "test": "kde"
-    }, 
     "openSUSE:Leap:42.3:Update": {
       "repos": [
         "http://download.opensuse.org/update/leap/42.3-test/", 


### PR DESCRIPTION
We are still actually running off an old version off f5c4750fdcc2f0f0123edbf9bbaf589adfa44f30 as advised by @coolo 
