### PR TITLE
pkglistgen: do_update_and_solve(): check for existence of :DVD instead of rings and pkglistgen-product-family-last config option.

### DIFF
--- a/osclib/conf.py
+++ b/osclib/conf.py
@@ -108,6 +108,7 @@ DEFAULT = {
         'pkglistgen-archs': 'x86_64',
         'pkglistgen-ignore-unresolvable': '1',
         'pkglistgen-ignore-recommended': '1',
+        'pkglistgen-product-family-last': 'SUSE:SLE-11:GA',
     },
     r'SUSE:(?P<project>.*$)': {
         'staging': 'SUSE:%(project)s:Staging',

--- a/osclib/util.py
+++ b/osclib/util.py
@@ -22,7 +22,7 @@ def project_list_family(apiurl, project):
 
     return filter(family_filter, projects)
 
-def project_list_family_prior(apiurl, project, include_self=False):
+def project_list_family_prior(apiurl, project, include_self=False, last=None):
     """
     Determine the available projects within the same product family released
     prior to the specified project.
@@ -38,6 +38,9 @@ def project_list_family_prior(apiurl, project, include_self=False):
 
         if past:
             prior.append(entry)
+
+        if entry == last:
+            break
 
     return prior
 

--- a/osclib/util.py
+++ b/osclib/util.py
@@ -13,7 +13,7 @@ def project_list_family(apiurl, project):
     count_original = project.count(':')
     if project.startswith('SUSE:SLE'):
         project = ':'.join(project.split(':')[:2])
-        family_filter = lambda p: p.endswith(':GA') and not p.startswith('SUSE:SLE-11')
+        family_filter = lambda p: p.count(':') == count_original and p.endswith(':GA')
     else:
         family_filter = lambda p: p.count(':') == count_original
 

--- a/pkglistgen.py
+++ b/pkglistgen.py
@@ -1169,9 +1169,10 @@ class CommandLineInterface(ToolBase.CommandLineInterface):
             # Ensure solv files from all releases in product family are updated.
             print('-> solv_cache_update')
             cache_dir_solv = save_cache_path('opensuse-packagelists', 'solv')
+            family_last = target_config.get('pkglistgen-product-family-last')
             family_include = target_config.get('pkglistgen-product-family-include')
             solv_prior = self.solv_cache_update(
-                apiurl, cache_dir_solv, target_project, family_include, opts)
+                apiurl, cache_dir_solv, target_project, family_last, family_include, opts)
 
             # Include pre-final release solv files for target project. These
             # files will only exist from previous runs.
@@ -1211,11 +1212,12 @@ class CommandLineInterface(ToolBase.CommandLineInterface):
             self.build_stub(release_dir, 'spec')
             self.commit_package(release_dir)
 
-    def solv_cache_update(self, apiurl, cache_dir_solv, target_project, family_include, opts):
+    def solv_cache_update(self, apiurl, cache_dir_solv, target_project, family_last, family_include, opts):
         """Dump solv files (do_dump_solv) for all products in family."""
         prior = set()
 
-        project_family = project_list_family_prior(apiurl, target_project, include_self=True)
+        project_family = project_list_family_prior(
+            apiurl, target_project, include_self=True, last=family_last)
         if family_include:
             # Include projects from a different family if desired.
             project_family.extend(project_list_family(apiurl, family_include))

--- a/pkglistgen.py
+++ b/pkglistgen.py
@@ -1065,7 +1065,7 @@ class CommandLineInterface(ToolBase.CommandLineInterface):
                     self.options.repos.append('/'.join([opts.project, 'bootstrap_copy']))
 
                 # DVD project first since it depends on main.
-                if api.rings:
+                if api.item_exists(opts.project + ':DVD'):
                     opts_dvd = copy.deepcopy(opts)
                     opts_dvd.project += ':DVD'
                     self.options.repos.insert(0, '/'.join([opts_dvd.project, main_repo]))

--- a/tests/util_tests.py
+++ b/tests/util_tests.py
@@ -66,6 +66,9 @@ class TestUtil(unittest.TestCase):
         projects = project_list_family_prior(None, 'openSUSE:Leap:15.0')
         self.assertEqual(projects, ['openSUSE:Leap:42.3', 'openSUSE:Leap:42.2'])
 
+        projects = project_list_family_prior(None, 'openSUSE:Leap:15.0', last='openSUSE:Leap:42.3')
+        self.assertEqual(projects, ['openSUSE:Leap:42.3'])
+
         projects = project_list_family_prior(None, 'openSUSE:Leap:42.3')
         self.assertEqual(projects, ['openSUSE:Leap:42.2'])
 

--- a/tests/util_tests.py
+++ b/tests/util_tests.py
@@ -25,12 +25,7 @@ class TestUtil(unittest.TestCase):
                 ]
             elif prefix == 'SUSE':
                 return [
-                    'SUSE:SLE-10',
-                    'SUSE:SLE-10:SP2',
-                    'SUSE:SLE-11',
-                    'SUSE:SLE-11:GA',
-                    'SUSE:SLE-11:SP1',
-                    'SUSE:SLE-11:SP1:Update',
+                    # Names reflect IBS as OBS differs for no apparent reason.
                     'SUSE:SLE-12:GA',
                     'SUSE:SLE-12-SP1:GA',
                     'SUSE:SLE-12-SP1:Update',


### PR DESCRIPTION
First fix towards #1392. I will likely update, but just published to start collecting any fixes needed.