### PR TITLE
pkglistgen: solv_cache_update(): support update repo and 4 way merge (and merge skipping)

### DIFF
--- a/osclib/conf.py
+++ b/osclib/conf.py
@@ -70,6 +70,7 @@ DEFAULT = {
         'delreq-review': None,
         'main-repo': 'standard',
         'download-baseurl': 'http://download.opensuse.org/distribution/leap/%(version)s/',
+        'download-baseurl-update': 'http://download.opensuse.org/update/leap/%(version)s/',
         # check_source.py
         # review-team optionally added by leaper.py.
         'repo-checker': 'repo-checker',

--- a/pkglistgen.py
+++ b/pkglistgen.py
@@ -1258,18 +1258,26 @@ class CommandLineInterface(ToolBase.CommandLineInterface):
             project_config = conf.config[project]
 
             baseurl = project_config.get('download-baseurl')
+            baseurl_update = project_config.get('download-baseurl-update')
             if not baseurl:
                 logger.warning('no baseurl configured for {}'.format(project))
                 continue
 
             urls = [urlparse.urljoin(baseurl, 'repo/oss/')]
+            if baseurl_update:
+                urls.append(urlparse.urljoin(baseurl_update, 'oss/'))
             if project_config.get('nonfree'):
                 urls.append(urlparse.urljoin(baseurl, 'repo/non-oss/'))
+                if baseurl_update:
+                    urls.append(urlparse.urljoin(baseurl_update, 'non-oss/'))
 
             names = []
             for url in urls:
+                project_display = project
+                if 'update' in url:
+                    project_display += ':Update'
                 print('-> do_dump_solv for {}/{}'.format(
-                    project, os.path.basename(os.path.normpath(url))))
+                    project_display, os.path.basename(os.path.normpath(url))))
                 logger.debug(url)
 
                 self.options.output_dir = os.path.join(cache_dir_solv, project)
@@ -1285,7 +1293,7 @@ class CommandLineInterface(ToolBase.CommandLineInterface):
 
             # Merge nonfree solv with free solv or copy free solv as merged.
             merged = names[0].replace('.solv', '.merged.solv')
-            if len(names) == 2:
+            if len(names) >= 2:
                 self.solv_merge(merged, *names)
             else:
                 shutil.copyfile(names[0], merged)

--- a/pkglistgen.py
+++ b/pkglistgen.py
@@ -784,6 +784,13 @@ class CommandLineInterface(ToolBase.CommandLineInterface):
                 self.solv_merge(solv_file, solv_file_nonfree, solv_file_merged)
 
     def solv_merge(self, solv1, solv2, solv_merged):
+        if os.path.exists(solv_merged):
+            modified = map(os.path.getmtime, [solv1, solv2, solv_merged])
+            if max(modified) <= modified[2]:
+                # The two inputs were modified before or at the same as merged.
+                logger.debug('merge skipped for {}'.format(solv_merged))
+                return
+
         with open(solv_merged, 'w') as handle:
             p = subprocess.Popen(['mergesolv', solv1, solv2], stdout=handle)
             p.communicate()


### PR DESCRIPTION
- 21961daf8a96f8411caa437201584e67f71bb75f:
    **pkglistgen: solv_cache_update(): support update repo and 4 way merge.**

- 460ab740d99b9a55f296a2b19c9af1be5a346312:
    pkglistgen: do_dump_solv(): support update repos.
    
    Always pull down update repo and only overwrite if changed. Could rework
    more extensively to name based on hash of repomd.xml or somesuch, but would
    likely also want to remove old versions.

- 84b142c00c321cb663c2cbba1809f46857fb867a:
    pkglistgen: solv_merge(): allow array of solv files to merge.

- df4e23c22df2ef6906a7965f707e917ba373f9ba:
    pkglistgen: solv_merge(): skip when inputs are older than merged.

- a11192affd5ec34dacf082cf2dfda06def962c41:
    osclib/conf: leap: set download-baseurl-update.

Fixes #1396.