### PR TITLE
Revert "staging: add exceptions for new 000* product files"

### DIFF
--- a/osclib/freeze_command.py
+++ b/osclib/freeze_command.py
@@ -257,8 +257,6 @@ class FreezeCommand(object):
         # If the package is an internal one (e.g _product)
         if package.startswith('_'):
             return None
-        if package.startswith('000'):
-            return None
 
         # Ignore packages with an origing (i.e. with an origin
         # different from the current project)

--- a/osclib/stagingapi.py
+++ b/osclib/stagingapi.py
@@ -198,7 +198,7 @@ class StagingAPI(object):
             for si in ET.parse(root).getroot().findall('sourceinfo'):
                 pkg = si.get('package')
                 # XXX TODO - Test-DVD-x86_64 is hardcoded here
-                if pkg in ret and not pkg.startswith('Test-DVD-') and not pkg.startswith('000'):
+                if pkg in ret and not pkg.startswith('Test-DVD-'):
                     msg = '{} is defined in two projects ({} and {})'
                     if checklinks and pkg in except_pkgs and prj == except_pkgs[pkg]:
                         msg = ''


### PR DESCRIPTION
This reverts commit 239c6314c7a8b0192c85181e7f64ab274e74cc31.

The whole purpose of freeze is not to have target changes affect the stagings. We didn't notice yet in Factory as we don't have the product builder there - but in SLE this is an ongoing problem