### PR TITLE
fix a typo that currently breaks token authentication

### DIFF
--- a/legal-auto.py
+++ b/legal-auto.py
@@ -205,7 +205,7 @@ class CommandLineInterface(ReviewBot.CommandLineInterface):
         bot.do_comments = self.options.comment
         bot.legaldb = self.options.legaldb
         if self.options.token:
-            self.legaldb_headers['Authorization'] = 'Token ' + self.options.token
+            bot.legaldb_headers['Authorization'] = 'Token ' + self.options.token
         return bot
 
 if __name__ == "__main__":


### PR DESCRIPTION
The `Authorization` value needs to be added to the `bot` object, not `self`.