### PR TITLE
ReviewBot: do not bother commenting for unhandled request type.

### DIFF
--- a/ReviewBot.py
+++ b/ReviewBot.py
@@ -297,9 +297,9 @@ class ReviewBot(object):
         return self.check_source_submission(a.src_project, a.src_package, a.src_rev, a.tgt_project, a.tgt_package)
 
     def check_action__default(self, req, a):
-        self.logger.error("unhandled request type %s"%a.type)
-        if self.comment_handler:
-            self.comment_write()
+        message = 'unhandled request type {}'.format(a.type)
+        self.logger.error(message)
+        self.review_messages['accepted'] += ': ' + message
         return self.request_default_return
 
     def check_source_submission(self, src_project, src_package, src_rev, target_project, target_package):


### PR DESCRIPTION
For consistency this would still make sense to post as a "report", but given the lack of such a facility in OBS disable comment to reduce noise.

```
./leaper.py -A ibs --dry --verbose id 156275
[I] checking 156275
[E] unhandled request type set_bugowner
[I] 156275 needs review by [leap-reviewers](/group/show/leap-reviewers)
[I] POST https://api.suse.de/request/156275?by_group=leap-reviewers&cmd=addreview
[I] can't change state, 156275 does not have the reviewer
[I] 156275 accepted: ok: unhandled request type set_bugowner
```

Fixes #1422.