### PR TITLE
Define comment commands and provide for ReviewBot review overrides and repo-checker skip-cycle.

### DIFF
--- a/legal-auto.py
+++ b/legal-auto.py
@@ -59,6 +59,7 @@ class LegalAuto(ReviewBot.ReviewBot):
             self.apinick = 'ibs#'
         else:
             self.apinick = 'obs#'
+        self.override_allow = False # Handled via external tool.
 
     def request_priority(self):
         prio = self.request.priority or 'moderate'

--- a/osclib/comments.py
+++ b/osclib/comments.py
@@ -112,6 +112,33 @@ class CommentAPI(object):
                 return c, info
         return None, None
 
+    def command_find(self, comments, user, command=None, who_allowed=None):
+        """
+        Find comment commands with the optional conditions.
+
+        Usage (in comment):
+            @<user> <command> [args...]
+        """
+        command_re = re.compile(r'^@(?P<user>[^ ]+) (?P<args>.*)$')
+
+        # Search for commands in the order the comment was created.
+        for comment in sorted(comments.values(), key=lambda c: c['when']):
+            if who_allowed and comment['who'] not in who_allowed:
+                continue
+
+            match = command_re.search(comment['comment'])
+            if not match:
+                continue
+
+            if match.group('user') != user:
+                continue
+
+            args = match.group('args').strip().split(' ')
+            if command and (args[0] or None) != command:
+                continue
+
+            yield args, comment['who']
+
     def add_marker(self, comment, bot, info=None):
         """Add bot marker to comment that can be used to find comment."""
 

--- a/osclib/conf.py
+++ b/osclib/conf.py
@@ -67,6 +67,7 @@ DEFAULT = {
         'openqa': 'https://openqa.opensuse.org',
         'lock': 'openSUSE:%(project)s:Staging',
         'lock-ns': 'openSUSE',
+        'leaper-override-group': 'leap-reviewers',
         'delreq-review': None,
         'main-repo': 'standard',
         'download-baseurl': 'http://download.opensuse.org/distribution/leap/%(version)s/',

--- a/osclib/core.py
+++ b/osclib/core.py
@@ -20,6 +20,15 @@ BINARY_REGEX = r'(?:.*::)?(?P<filename>(?P<name>.*?)-(?P<version>[^-]+)-(?P<rele
 RPM_REGEX = BINARY_REGEX + '\.rpm'
 BinaryParsed = namedtuple('BinaryParsed', ('package', 'filename', 'name', 'arch'))
 
+@memoize(session=True)
+def group_members(apiurl, group, maintainers=False):
+    url = makeurl(apiurl, ['group', group])
+    root = ETL.parse(http_GET(url)).getroot()
+
+    if maintainers:
+        return root.xpath('maintainer/@userid')
+
+    return root.xpath('person/person/@userid')
 
 @memoize(session=True)
 def owner_fallback(apiurl, project, package):

--- a/osclib/core.py
+++ b/osclib/core.py
@@ -49,9 +49,7 @@ def maintainers_get(apiurl, project, package=None):
     maintainers = [p.get('name') for p in root.findall('.//person') if p.get('role') == 'maintainer']
     if not maintainers:
         for group in [p.get('name') for p in root.findall('.//group') if p.get('role') == 'maintainer']:
-            url = makeurl(apiurl, ('group', group))
-            root = ET.parse(http_GET(url)).getroot()
-            maintainers = maintainers + [p.get('userid') for p in root.findall('./person/person')]
+            maintainers = maintainers + group_members(apiurl, group)
     return maintainers
 
 @memoize(session=True)

--- a/repo_checker.py
+++ b/repo_checker.py
@@ -181,9 +181,8 @@ class RepoChecker(ReviewBot.ReviewBot):
                 self.groups_build[group] = hashlib.sha1(''.join(builds)).hexdigest()[:7]
 
                 # Determine if build has changed since last comment.
-                comment_api = CommentAPI(api.apiurl)
-                comments = comment_api.get_comments(project_name=group)
-                _, info = comment_api.comment_find(comments, self.bot_name)
+                comments = self.comment_api.get_comments(project_name=group)
+                _, info = self.comment_api.comment_find(comments, self.bot_name)
                 if info and self.groups_build[group] == info.get('build'):
                     skip_build.add(group)
 

--- a/repo_checker.py
+++ b/repo_checker.py
@@ -121,6 +121,7 @@ class RepoChecker(ReviewBot.ReviewBot):
         self.requests_map = {}
         self.groups = {}
         self.groups_build = {}
+        self.groups_skip_cycle = []
 
         # Manipulated in ensure_group().
         self.group = None
@@ -185,6 +186,14 @@ class RepoChecker(ReviewBot.ReviewBot):
                 _, info = self.comment_api.comment_find(comments, self.bot_name)
                 if info and self.groups_build[group] == info.get('build'):
                     skip_build.add(group)
+
+                # Look for skip-cycle comment command.
+                users = self.request_override_check_users(request.actions[0].tgt_project)
+                for _, who in self.comment_api.command_find(
+                    comments, self.review_user, 'skip-cycle', users):
+                    self.logger.debug('comment command: skip-cycle by {}'.format(who))
+                    self.groups_skip_cycle.append(group)
+                    break
 
             if not self.force and group in skip_build:
                 self.logger.debug('{}: {} build unchanged'.format(request.reqid, group))
@@ -418,8 +427,8 @@ class RepoChecker(ReviewBot.ReviewBot):
             yield InstallSection(section, text)
 
     def cycle_check(self, project, stagings, arch):
-        if self.skip_cycle:
-            self.logger.info('cycle check: skip due to --skip-cycle')
+        if self.skip_cycle or self.group in self.groups_skip_cycle:
+            self.logger.info('cycle check: skip due to --skip-cycle or comment command')
             return CheckResult(True, None)
 
         self.logger.info('cycle check: start')

--- a/tests/checktags_tests.py
+++ b/tests/checktags_tests.py
@@ -60,6 +60,7 @@ class TestTagChecker(unittest.TestCase):
         self.checker = TagChecker(apiurl=APIURL,
                                   user='maintbot',
                                   logger=self.logger)
+        self.checker.override_allow = False # Test setup cannot handle.
 
         self._request_data = """
                 <request id="293129" creator="darix">

--- a/tests/factory_source_tests.py
+++ b/tests/factory_source_tests.py
@@ -57,6 +57,7 @@ class TestFactorySourceAccept(unittest.TestCase):
         self.checker = FactorySourceChecker(apiurl = APIURL, \
                 user = 'factory-source', \
                 logger = self.logger)
+        self.checker.override_allow = False # Test setup cannot handle.
 
     def test_accept_request(self):
 

--- a/tests/maintenance_tests.py
+++ b/tests/maintenance_tests.py
@@ -55,6 +55,7 @@ class TestMaintenance(unittest.TestCase):
         self.checker = MaintenanceChecker(apiurl = APIURL, \
                 user = 'maintbot', \
                 logger = self.logger)
+        self.checker.override_allow = False # Test setup cannot handle.
 
     def test_non_maintainer_submit(self):
         """same as above but already has devel project as reviewer


### PR DESCRIPTION
- 68b93e1dbd4fbb395bb1ea4cf6aec35a45f4babb:
    repo_checker: provide comment command to skip-cycle for group.
    
    For example (on staging project):
    
      @repo-checker skip-cycle

- 4f4e6da7efc48fc43dd63138081b61d9df01c960:
    repo_checker: utilize ReviewBot.comment_api instead of new instance.

- e775d440494d39291b4ded228abb6ed3555463d3:
    ReviewBot: provide comment command override.
    
    For example:
    
      @leaper override accept
      @repo-checker override decline

- 3674191a41f4d6f82c530eee14ac85ce86150e3a:
    osclib/core: maintainers_get(): utilize new group_members() function.

- e2efbf55a90b98755f9e889bf501069ca5405ad1:
    osclib/core: provide group_members() function.

- eb19b827aa1b82dcf1880c98d761c5caed6ee2c7:
    osclib/comments: provide command_find() for comment commands.

Fixes #1400.
Fixes #1365.

Should partial work towards #1181, but would likely need to scan declined reviews to see if re-open or change workflow for bots like `factory-auto`.