### PR TITLE
leaper: do not decline SLE requests, but rather ask managers for input.

### DIFF
--- a/leaper.py
+++ b/leaper.py
@@ -199,6 +199,13 @@ class Leaper(ReviewBot.ReviewBot):
             #self.logger.info('no matching sources in Factory, Leap:15.0, nor devel project')
             self.logger.info('no matching sources in Factory, nor devel project')
 
+            if origin_same is False:
+                # Rather than decline, leave review open in-case of change and
+                # ask release manager for input via override comment.
+                self.logger.info('Comment `(at){} override accept` to force accept.'.format(self.review_user))
+                self.needs_release_manager = True
+                return None
+
             return origin_same
 
         if package in self.lookup_150:

--- a/leaper.py
+++ b/leaper.py
@@ -63,9 +63,9 @@ class Leaper(ReviewBot.ReviewBot):
         self.pending_factory_submission = False
         self.source_in_factory = None
         self.needs_release_manager = False
-        self.release_manager_group = 'leap-reviewers'
-        self.review_team_group = 'opensuse-review-team'
-        self.legal_review_group = 'legal-auto'
+        self.release_manager_group = None
+        self.review_team_group = None
+        self.legal_review_group = None
         self.must_approve_version_updates = False
         self.must_approve_maintenance_updates = False
         self.needs_check_source = False
@@ -427,6 +427,8 @@ class Leaper(ReviewBot.ReviewBot):
         return False
 
     def check_one_request(self, req):
+        api = self.staging_api(req.actions[0].tgt_project)
+        config = self.staging_config[api.project]
         self.needs_legal_review = False
         self.needs_reviewteam = False
         self.needs_release_manager = False
@@ -472,11 +474,14 @@ class Leaper(ReviewBot.ReviewBot):
 
         add_review_groups = []
         if self.needs_release_manager:
-            add_review_groups.append(self.release_manager_group)
+            add_review_groups.append(self.release_manager_group or
+                                     config.get(self.override_group_key))
         if self.needs_reviewteam:
-            add_review_groups.append(self.review_team_group)
+            add_review_groups.append(self.review_team_group or
+                                     config.get('review-team'))
         if self.needs_legal_review:
-            add_review_groups.append(self.legal_review_group)
+            add_review_groups.append(self.legal_review_group or
+                                     config.get('legal-review-group'))
         if self.needs_check_source and self.check_source_group is not None:
             add_review_groups.append(self.check_source_group)
 
@@ -507,9 +512,9 @@ class CommandLineInterface(ReviewBot.CommandLineInterface):
         parser.add_option("--manual-version-updates", action="store_true", help="release manager must approve version updates")
         parser.add_option("--manual-maintenance-updates", action="store_true", help="release manager must approve maintenance updates")
         parser.add_option("--check-source-group", dest="check_source_group", metavar="GROUP", help="group used by check_source.py bot which will be added as a reviewer should leaper checks pass")
-        parser.add_option("--review-team-group", dest="review_team_group", metavar="GROUP", help="group used for package reviews", default="opensuse-review-team")
-        parser.add_option("--release-manager-group", dest="release_manager_group", metavar="GROUP", help="group used for release manager reviews", default="leap-reviewers")
-        parser.add_option("--legal-review-group", dest="legal_review_group", metavar="GROUP", help="group used for legal reviews", default="legal-auto")
+        parser.add_option("--review-team-group", dest="review_team_group", metavar="GROUP", help="group used for package reviews")
+        parser.add_option("--release-manager-group", dest="release_manager_group", metavar="GROUP", help="group used for release manager reviews")
+        parser.add_option("--legal-review-group", dest="legal_review_group", metavar="GROUP", help="group used for legal reviews")
 
         return parser
 

--- a/osclib/conf.py
+++ b/osclib/conf.py
@@ -51,6 +51,7 @@ DEFAULT = {
         # check_source.py
         'devel-project-enforce': 'True',
         'review-team': 'opensuse-review-team',
+        'legal-review-group': 'legal-auto',
         'repo-checker': 'repo-checker',
         'pkglistgen-product-family-include': 'openSUSE:Leap:N',
     },
@@ -72,6 +73,8 @@ DEFAULT = {
         'main-repo': 'standard',
         'download-baseurl': 'http://download.opensuse.org/distribution/leap/%(version)s/',
         'download-baseurl-update': 'http://download.opensuse.org/update/leap/%(version)s/',
+        'review-team': 'opensuse-review-team',
+        'legal-review-group': 'legal-auto',
         # check_source.py
         # review-team optionally added by leaper.py.
         'repo-checker': 'repo-checker',

--- a/osclib/conf.py
+++ b/osclib/conf.py
@@ -106,6 +106,7 @@ DEFAULT = {
         'openqa': None,
         'lock': 'SUSE:%(project)s:Staging',
         'lock-ns': 'SUSE',
+        'leaper-override-group': 'sle-release-managers',
         'delreq-review': None,
         'main-repo': 'standard',
         # check_source.py


### PR DESCRIPTION
- 16f49c7518f9d1b39145b8091671cea776c90487:
    leaper: do not decline SLE requests, but rather ask managers for input.

- 5e2834e4bda1d9b53365dd6f0ec37b3e3f6056cf:
    osclib/conf: configure SLE-15 leaper-override-group.

- 8332692dada7a5ef89ad1c10463959b18ba4c947:
    leaper: move review groups to osclib.conf.

Output when `origin_same` forced to `False`.

```
./leaper.py -A ibs --dry --verbose id 156436
[I] checking 156436
[I] home:mcgrof:branches:SUSE:SLE-15:GA/xfsprogs@2 -> SUSE:SLE-15:GA/xfsprogs
[I] expected origin is 'FORK' (unchanged)
[I] obsrq#583263 to openSUSE:Factory has different sources
[I] different sources in [openSUSE.org:openSUSE:Factory/xfsprogs](/package/rdiff/home:mcgrof:branches:SUSE:SLE-15:GA/xfsprogs?opackage=xfsprogs&oproject=openSUSE.org:openSUSE:Factory&rev=2)
[I] different sources in [openSUSE.org:filesystems/xfsprogs](/package/rdiff/home:mcgrof:branches:SUSE:SLE-15:GA/xfsprogs?opackage=xfsprogs&oproject=openSUSE.org:filesystems&rev=2)
[I] no matching sources in Factory, nor devel project
[I] Comment `(at)leaper override accept` to force accept.
[I] the submitted sources are NOT in Factory
[I] 156436 needs review by [sle-release-managers](/group/show/sle-release-managers)
[I] 156436 ignored
```

Fixes #1397.