### PR TITLE
osclib/staging-api: lazy-load all config values to allow for placement in remote config.

### DIFF
--- a/osclib/accept_command.py
+++ b/osclib/accept_command.py
@@ -48,7 +48,7 @@ class AcceptCommand(object):
         return True
 
     def find_virtually_accepted_requests(self, project):
-        query = "match=state/@name='review'+and+(action/target/@project='{}'+and+action/@type='delete')+and+(review/@state='new'+and+review/@by_group='{}')".format(project, self.api.delreq_review)
+        query = "match=state/@name='review'+and+(action/target/@project='{}'+and+action/@type='delete')+and+(review/@state='new'+and+review/@by_group='{}')".format(project, self.api.cdelreq_review)
         url = self.api.makeurl(['search', 'request'], query)
 
         f = http_GET(url)
@@ -86,7 +86,7 @@ class AcceptCommand(object):
         http_PUT(url + '?comment=accept+command+update', data=content)
 
     def virtually_accept_delete(self, request_id, package):
-        self.api.add_review(request_id, by_group=self.api.delreq_review, msg='Request accepted. Cleanup in progress - DO NOT REVOKE!')
+        self.api.add_review(request_id, by_group=self.api.cdelreq_review, msg='Request accepted. Cleanup in progress - DO NOT REVOKE!')
 
         filelist = self.api.get_filelist_for_package(pkgname=package, project=self.api.project, expand='1', extension='spec')
         pkgs = self.api.extract_specfile_short(filelist)
@@ -129,7 +129,7 @@ class AcceptCommand(object):
             oldspecs = self.api.get_filelist_for_package(pkgname=req['package'],
                                                          project=self.api.project,
                                                          extension='spec')
-            if 'type' in req and req['type'] == 'delete' and self.api.delreq_review:
+            if 'type' in req and req['type'] == 'delete' and self.api.cdelreq_review:
                 msg += ' and started handling of virtual accept process'
                 print(msg)
                 # Virtually accept the delete request
@@ -189,13 +189,13 @@ class AcceptCommand(object):
     def accept_other_new(self):
         changed = False
 
-        if self.api.delreq_review:
+        if self.api.cdelreq_review:
             rqlist = self.find_virtually_accepted_requests(self.api.project)
             for req in rqlist:
                 if self.virtual_accept_request_has_no_binary(self.api.project, req['packages'][0]):
                     # Accepting delreq-review review
                     self.api.do_change_review_state(req['id'], 'accepted',
-                                                    by_group=self.api.delreq_review,
+                                                    by_group=self.api.cdelreq_review,
                                                     message='Virtually accepted delete {}'.format(req['packages'][0]))
 
         rqlist = self.find_new_requests(self.api.project)

--- a/osclib/accept_command.py
+++ b/osclib/accept_command.py
@@ -97,7 +97,7 @@ class AcceptCommand(object):
             meta = ''.join(meta)
             # Update package meta to disable build
             self.api.create_package_container(self.api.project, pkg, meta=meta, disable_build=True)
-            wipebinaries(self.api.apiurl, self.api.project, package=pkg, repo=self.api.main_repo)
+            wipebinaries(self.api.apiurl, self.api.project, package=pkg, repo=self.api.cmain_repo)
 
             # Remove package from Rings
             if self.api.ring_packages.get(pkg):

--- a/osclib/accept_command.py
+++ b/osclib/accept_command.py
@@ -154,7 +154,7 @@ class AcceptCommand(object):
             return False
 
         pkglist = self.api.list_packages(project)
-        clean_list = set(pkglist) - set(self.api.cstaging_nocleanup)
+        clean_list = set(pkglist) - set(self.api.cnocleanup_packages)
 
         for package in clean_list:
             print "[cleanup] deleted %s/%s" % (project, package)

--- a/osclib/stagingapi.py
+++ b/osclib/stagingapi.py
@@ -68,7 +68,6 @@ class StagingAPI(object):
 
         # Store some prefix / data used in the code.
         self.user = conf.get_apiurl_usr(apiurl)
-        self.delreq_review = conf.config[project]['delreq-review']
         self.main_repo = conf.config[project]['main-repo']
         self._ring_packages = None
         self._ring_packages_for_links = None

--- a/osclib/stagingapi.py
+++ b/osclib/stagingapi.py
@@ -67,7 +67,6 @@ class StagingAPI(object):
         self.project = project
 
         # Store some prefix / data used in the code.
-        self._cstaging_nocleanup = None
         self.user = conf.get_apiurl_usr(apiurl)
         self.delreq_review = conf.config[project]['delreq-review']
         self.main_repo = conf.config[project]['main-repo']
@@ -98,7 +97,7 @@ class StagingAPI(object):
 
             # This will intentionally cause error if key does not exists.
             value = conf.config[self.project][key]
-            if key.endswith('archs'):
+            if key.endswith('archs') or key == 'nocleanup-packages':
                 value = value.split()
 
             # This code will only be called for the first access.
@@ -107,14 +106,6 @@ class StagingAPI(object):
 
         # Raise AttributeError like normal.
         return self.__getattribute__(attr)
-
-    @property
-    def cstaging_nocleanup(self):
-        """Lazy-load value to allow for placement in remote config."""
-        if self._cstaging_nocleanup is None:
-            self._cstaging_nocleanup = conf.config[self.project]['nocleanup-packages'].split()
-
-        return self._cstaging_nocleanup
 
     @property
     def ring_packages(self):

--- a/osclib/stagingapi.py
+++ b/osclib/stagingapi.py
@@ -68,7 +68,6 @@ class StagingAPI(object):
 
         # Store some prefix / data used in the code.
         self.user = conf.get_apiurl_usr(apiurl)
-        self.main_repo = conf.config[project]['main-repo']
         self._ring_packages = None
         self._ring_packages_for_links = None
         self._packages_staged = None
@@ -1284,7 +1283,7 @@ class StagingAPI(object):
         url = self.makeurl(['source', project, '_meta'])
         meta = ET.parse(http_GET(url))
 
-        repository = meta.find('repository[@name="{}"]'.format(self.main_repo))
+        repository = meta.find('repository[@name="{}"]'.format(self.cmain_repo))
         changed = False
         for arch in self.cstaging_archs:
             if not repository.xpath('./arch[text()="{}"]'.format(arch)):


### PR DESCRIPTION
- e450a1519ee9083ff2580901c44241c1afab7ff8:
    osclib/stagingapi: rename main_repo to cmain_repo.
    
    The previous name is inconsistent and did not work with general lazy laod.

- 4bd9e9a2fbf5d0407e7b2aef1b2ff2cc10be1e67:
    osclib/stagingapi: rename delreq_review to cdelreq_review.
    
    The previous name is inconsistent and did not work with general lazy laod.

- d790a2ce6928b723c1152fbbe73c4300a44849c3:
    osclib/stagingapi: rename cstaging_nocleanup to cnocleanup_packages.
    
    The previous name is inconsistent and did not work with general lazy laod.

- e3168d6c3426aa10ebde1e9780acd8a50e6b3e9a:
    osclib/staging-api: lazy-load all config values to allow for placement in remote config.

Feel free to test this out as we have many use-cases and few tests. I made sure the values I replaced worked for `Factory` which means the lazy-load worked and confirmed that `memoize handlers seem to still work as well.

Further fixes #1428 as even the `staging-group` should be override-able in remote config.