### PR TITLE
create_test_Factory: No longer block kdelibs4-branding-upstream

### DIFF
--- a/create_test_Factory_dvd-2.testcase
+++ b/create_test_Factory_dvd-2.testcase
@@ -55,7 +55,6 @@ job lock name gdm-branding-upstream
 job lock name kdebase4-workspace-branding-upstream
 job lock name kdm-branding-upstream
 job lock name kdebase4-runtime-branding-upstream
-job lock name kdelibs4-branding-upstream
 job lock name sddm-branding-upstream
 job lock name plasma5-desktop-branding-upstream
 job lock name plasma5-workspace-branding-upstream


### PR DESCRIPTION
kdelibs4-branding-openSUSE has been dropped, since there is nothing useful
left in it, and kdebase4 is slowly dying.