### PR TITLE
osclib/git: provide git utilities: clone() and sync() and utilize in issue-diff.py.

### DIFF
--- a/issue-diff.py
+++ b/issue-diff.py
@@ -243,7 +243,7 @@ def main(args):
 
     git_repo_url = 'git@github.com:jberry-suse/osc-plugin-factory-issue-db.git'
     git_message = 'Sync issue-diff.py changes.'
-    db_dir = sync(args.config_dir, git_repo_url, git_message)
+    db_dir = sync(args.cache_dir, git_repo_url, git_message)
     db_file = os.path.join(db_dir, '{}.yml'.format(args.project))
 
     if os.path.exists(db_file):
@@ -393,7 +393,7 @@ def main(args):
             print('stopped at limit')
             break
 
-    sync(args.config_dir, git_repo_url, git_message)
+    sync(args.cache_dir, git_repo_url, git_message)
 
 
 if __name__ == '__main__':
@@ -412,11 +412,11 @@ if __name__ == '__main__':
     parser.add_argument('-p', '--project', default='SUSE:SLE-12-SP3:GA', metavar='PROJECT', help='project to check for issues that have are not found in factory')
     parser.add_argument('--newest', type=int, default='30', metavar='AGE_IN_DAYS', help='newest issues to be considered')
     parser.add_argument('--limit', type=int, default='0', help='limit number of packages with new issues processed')
-    parser.add_argument('--config-dir', help='configuration directory containing git-sync tool and issue db')
+    parser.add_argument('--cache-dir', help='cache directory containing git-sync tool and issue db')
     parser.add_argument('--print-stats', action='store_true', help='print statistics based on database')
     args = parser.parse_args()
 
-    if args.config_dir is None:
-        args.config_dir = CACHE_DIR
+    if args.cache_dir is None:
+        args.cache_dir = CACHE_DIR
 
     sys.exit(main(args))

--- a/osclib/git.py
+++ b/osclib/git.py
@@ -1,0 +1,46 @@
+import os
+from os import path
+import subprocess
+from xdg.BaseDirectory import save_cache_path
+
+CACHE_DIR = save_cache_path('osc-plugin-factory', 'git')
+
+def clone(url, directory):
+    return_code = subprocess.call(['git', 'clone', url, directory])
+    if return_code != 0:
+        raise Exception('Failed to clone {}'.format(url))
+
+def sync(cache_dir, repo_url, message=None):
+    cwd = os.getcwd()
+    devnull = open(os.devnull, 'wb')
+
+    # Ensure git-sync tool is available.
+    git_sync_dir = path.join(cache_dir, 'git-sync')
+    git_sync_exec = path.join(git_sync_dir, 'git-sync')
+    if not path.exists(git_sync_dir):
+        os.makedirs(git_sync_dir)
+        clone('https://github.com/simonthum/git-sync.git', git_sync_dir)
+    else:
+        os.chdir(git_sync_dir)
+        subprocess.call(['git', 'pull', 'origin', 'master'], stdout=devnull, stderr=devnull)
+
+    repo_name = path.basename(path.normpath(repo_url))
+    repo_dir = path.join(cache_dir, repo_name)
+    if not path.exists(repo_dir):
+        os.makedirs(repo_dir)
+        clone(repo_url, repo_dir)
+
+        os.chdir(repo_dir)
+        subprocess.call(['git', 'config', '--bool', 'branch.master.sync', 'true'])
+        subprocess.call(['git', 'config', '--bool', 'branch.master.syncNewFiles', 'true'])
+        if message:
+            subprocess.call(['git', 'config', 'branch.master.syncCommitMsg', message])
+
+    os.chdir(repo_dir)
+    return_code = subprocess.call([git_sync_exec])
+    if return_code != 0:
+        raise Exception('failed to sync {}'.format(repo_name))
+
+    os.chdir(cwd)
+
+    return repo_dir


### PR DESCRIPTION
- da7e0b43d68404a83a31eae78f25cc00b7bcf016:
    issue-diff: rename --config-dir as --cache-dir to be more accurate.

- 17b6f0b7535d43692c0e9955f17cd5c429ef8bac:
    issue-diff: replace git sync functionality with osclib.git.

- 90d538606d7503d399c71eb5f146a95062425ba1:
    osclib/git: provide git utilities: clone() and sync().
    
    Derived from issue-diff.py which was abstracted in
    boombatower/tumbleweed-review.

Should be useful for #1438.