### PR TITLE
pkglistgen: Do not run local service check when committing to release package

### DIFF
--- a/pkglistgen.py
+++ b/pkglistgen.py
@@ -1350,7 +1350,7 @@ class CommandLineInterface(ToolBase.CommandLineInterface):
             # No proper API function to perform the same operation.
             print(subprocess.check_output(
                 ' '.join(['cd', path, '&&', 'osc', 'addremove']), shell=True))
-            package.commit(msg='Automatic update')
+            package.commit(msg='Automatic update', skip_local_service_run=True)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
That check is aiming to check request rather than package, for release package we indeed had multispecs and multibuild file together, just do not run local service when committing to release package.

fixes https://github.com/openSUSE/osc-plugin-factory/issues/1440