### PR TITLE
services: Add Install section to totest-manager service

### DIFF
--- a/systemd/osrt-totest-manager@.service
+++ b/systemd/osrt-totest-manager@.service
@@ -6,3 +6,7 @@ Type=simple
 User=osrt-totest-manager
 WorkingDirectory=~
 ExecStart=/usr/bin/osrt-totest-manager --verbose run --interval 5 "%i"
+
+[Install]
+WantedBy=multi-user.target
+


### PR DESCRIPTION
Without an install section, systemctl enable osrt-totest-manager@openSUSE:Factory has no effect, which in turn results in the service not running upon reboot (unless manually being symlinked, whichis definitively not the way to go)