### PR TITLE
Use opensuse/tumbleweed in the Dockerfile

### DIFF
--- a/dist/ci/Dockerfile
+++ b/dist/ci/Dockerfile
@@ -1,7 +1,7 @@
 # https://docs.docker.com/engine/reference/builder/
 # Used for TEST_SUITE=distribution and deployment to OBS.
 
-FROM opensuse:tumbleweed
+FROM opensuse/tumbleweed
 MAINTAINER Jimmy Berry <jberry@suse.com>
 
 # https://github.com/openSUSE/obs-service-set_version/issues/44 python-packaging


### PR DESCRIPTION
opensuse:tumbleweed will be removed and we want dogfooding anyway.

Fixes #1460. (added by jberry-suse)